### PR TITLE
fix: use directory context by forking execution

### DIFF
--- a/internal/cache/load.go
+++ b/internal/cache/load.go
@@ -143,7 +143,7 @@ func (s *Snapshot) load(ctx context.Context, allowNetwork bool, scopes ...loadSc
 	event.Error(ctx, "DEBUG:inv", fmt.Errorf("debug query: %+v", query))
 
 	cfg := s.config(ctx, inv)
-	if bindriver := os.Getenv("GOPACKAGESDRIVER"); bindriver == "" || bindriver != "off" {
+	if bindriver := os.Getenv("GOPACKAGESDRIVER"); bindriver == ":memory:" {
 		cfg.PackagesDriver = packagesResolver
 	}
 


### PR DESCRIPTION
An issue arose in certain scenarios where context execution was not provided correctly when using an in-memory loader, leading to errors when using the package inside the `gno` folder (for example, for ex.) with some specific `lsp` tools. 

This PR rolls back the in-memory execution of the loader, reverting to a forking cmd option while still using `gnopls` as a single executable. 

The in-memory option remains available as `GOPACKAGESDRIVER=:memory:`, but is not recommended if working inside the gno repo.

@leohhhn can you confirm this fix your issue ?