### PR TITLE
fix: update some remaining mode file references go.mod -> gno.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: install
 install:
-	go install .
+	go install -v .

--- a/doc/generate/generate.go
+++ b/doc/generate/generate.go
@@ -482,7 +482,7 @@ func loadLenses(settingsPkg *packages.Package, defaults map[settings.CodeLensSou
 		return nil
 	}
 	addAll(golang.CodeLensSources(), "Go")
-	addAll(mod.CodeLensSources(), "go.mod")
+	addAll(mod.CodeLensSources(), "gno.mod")
 	return lenses, nil
 }
 

--- a/internal/cache/load.go
+++ b/internal/cache/load.go
@@ -708,7 +708,7 @@ func isWorkspacePackageLocked(ctx context.Context, s *Snapshot, meta *metadata.G
 			}
 			dir := pkg.CompiledGoFiles[0].Dir()
 			var err error
-			modURI, err = findRootPattern(ctx, dir, "go.mod", lockedSnapshot{s})
+			modURI, err = findRootPattern(ctx, dir, "gno.mod", lockedSnapshot{s})
 			if err != nil || modURI == "" {
 				// err != nil implies context cancellation, in which case the result of
 				// this query does not matter.

--- a/internal/cache/mod_tidy.go
+++ b/internal/cache/mod_tidy.go
@@ -110,7 +110,7 @@ func modTidyImpl(ctx context.Context, snapshot *Snapshot, pm *ParsedModule) (*Ti
 
 	inv, cleanupInvocation, err := snapshot.GoCommandInvocation(false, &gocommand.Invocation{
 		Verb:       "mod",
-		Args:       []string{"tidy", "-modfile=" + filepath.Join(tempDir, "go.mod")},
+		Args:       []string{"tidy", "-modfile=" + filepath.Join(tempDir, "gno.mod")},
 		Env:        []string{"GOWORK=off"},
 		WorkingDir: pm.URI.Dir().Path(),
 	})
@@ -124,7 +124,7 @@ func modTidyImpl(ctx context.Context, snapshot *Snapshot, pm *ParsedModule) (*Ti
 
 	// Go directly to disk to get the temporary mod file,
 	// since it is always on disk.
-	tempMod := filepath.Join(tempDir, "go.mod")
+	tempMod := filepath.Join(tempDir, "gno.mod")
 	tempContents, err := os.ReadFile(tempMod)
 	if err != nil {
 		return nil, err

--- a/internal/cache/session.go
+++ b/internal/cache/session.go
@@ -585,7 +585,7 @@ func RelevantViews[V viewDefiner](ctx context.Context, fs file.Source, uri proto
 		return nil, nil // avoid the call to findRootPattern
 	}
 	dir := uri.Dir()
-	modURI, err := findRootPattern(ctx, dir, "go.mod", fs)
+	modURI, err := findRootPattern(ctx, dir, "gno.mod", fs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cache/session_test.go
+++ b/internal/cache/session_test.go
@@ -68,7 +68,7 @@ func TestZeroConfigAlgorithm(t *testing.T) {
 		{
 			"basic go.mod workspace",
 			map[string]string{
-				"go.mod": "module golang.org/a\ngo 1.18\n",
+				"gno.mod": "module golang.org/a\ngo 1.18\n",
 			},
 			[]folderSummary{{dir: "."}},
 			nil,
@@ -237,7 +237,7 @@ func TestZeroConfigAlgorithm(t *testing.T) {
 		{
 			"go.mod with nested replace",
 			map[string]string{
-				"go.mod":   "module golang.org/a\n require golang.org/b v1.2.3\nreplace example.com/b => ./b",
+				"gno.mod":   "module golang.org/a\n require golang.org/b v1.2.3\nreplace example.com/b => ./b",
 				"a.go":     "package a",
 				"b/go.mod": "module golang.org/b\ngo 1.18\n",
 				"b/b.go":   "package b",
@@ -249,7 +249,7 @@ func TestZeroConfigAlgorithm(t *testing.T) {
 		{
 			"go.mod with parent replace, parent folder",
 			map[string]string{
-				"go.mod":   "module golang.org/a",
+				"gno.mod":   "module golang.org/a",
 				"a.go":     "package a",
 				"b/go.mod": "module golang.org/b\ngo 1.18\nrequire golang.org/a v1.2.3\nreplace golang.org/a => ../",
 				"b/b.go":   "package b",
@@ -261,7 +261,7 @@ func TestZeroConfigAlgorithm(t *testing.T) {
 		{
 			"go.mod with multiple replace",
 			map[string]string{
-				"go.mod": `
+				"gno.mod": `
 module golang.org/root
 
 require (
@@ -291,7 +291,7 @@ replace (
 		{
 			"go.mod with replace outside the workspace",
 			map[string]string{
-				"go.mod":   "module golang.org/a\ngo 1.18",
+				"gno.mod":   "module golang.org/a\ngo 1.18",
 				"a.go":     "package a",
 				"b/go.mod": "module golang.org/b\ngo 1.18\nrequire golang.org/a v1.2.3\nreplace golang.org/a => ../",
 				"b/b.go":   "package b",
@@ -303,7 +303,7 @@ replace (
 		{
 			"go.mod with replace directive; workspace replace off",
 			map[string]string{
-				"go.mod":   "module golang.org/a\n require golang.org/b v1.2.3\nreplace example.com/b => ./b",
+				"gno.mod":   "module golang.org/a\n require golang.org/b v1.2.3\nreplace example.com/b => ./b",
 				"a.go":     "package a",
 				"b/go.mod": "module golang.org/b\ngo 1.18\n",
 				"b/b.go":   "package b",

--- a/internal/cache/snapshot.go
+++ b/internal/cache/snapshot.go
@@ -427,7 +427,7 @@ func (s *Snapshot) RunGoModUpdateCommands(ctx context.Context, modURI protocol.D
 	inv, cleanupInvocation, err := s.GoCommandInvocation(true, &gocommand.Invocation{
 		WorkingDir: modURI.Dir().Path(),
 		ModFlag:    "mod",
-		ModFile:    filepath.Join(tempDir, "go.mod"),
+		ModFile:    filepath.Join(tempDir, "gno.mod"),
 		Env:        []string{"GOWORK=off"},
 	})
 	if err != nil {
@@ -443,7 +443,7 @@ func (s *Snapshot) RunGoModUpdateCommands(ctx context.Context, modURI protocol.D
 		return nil, nil, err
 	}
 	var modBytes, sumBytes []byte
-	modBytes, err = os.ReadFile(filepath.Join(tempDir, "go.mod"))
+	modBytes, err = os.ReadFile(filepath.Join(tempDir, "gno.mod"))
 	if err != nil && !os.IsNotExist(err) {
 		return nil, nil, err
 	}
@@ -480,7 +480,7 @@ func TempModDir(ctx context.Context, fs file.Source, modURI protocol.DocumentURI
 		return "", nil, err // context cancelled
 	}
 	if data, err := modFH.Content(); err == nil {
-		if err := os.WriteFile(filepath.Join(dir, "go.mod"), data, 0666); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "gno.mod"), data, 0666); err != nil {
 			return "", nil, err
 		}
 	}
@@ -1770,7 +1770,7 @@ func (s *Snapshot) clone(ctx, bgCtx context.Context, changed StateChange, done f
 			reinit = true
 		}
 		if base == "go.sum" {
-			modURI := protocol.URIFromPath(filepath.Join(dir, "go.mod"))
+			modURI := protocol.URIFromPath(filepath.Join(dir, "gno.mod"))
 			if _, active := result.view.workspaceModFiles[modURI]; active {
 				reinit = true
 			}

--- a/internal/cache/view.go
+++ b/internal/cache/view.go
@@ -864,7 +864,7 @@ func defineView(ctx context.Context, fs file.Source, folder *Folder, forFile fil
 
 	// When deriving the best view for a given file, we only want to search
 	// up the directory hierarchy for modfiles.
-	def.gomod, err = findRootPattern(ctx, dirURI, "go.mod", fs)
+	def.gomod, err = findRootPattern(ctx, dirURI, "gno.mod", fs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cache/workspace.go
+++ b/internal/cache/workspace.go
@@ -54,7 +54,7 @@ func localModFiles(relativeTo string, goWorkOrModPaths []string) map[protocol.Do
 		if !filepath.IsAbs(modDir) {
 			modDir = filepath.Join(relativeTo, modDir)
 		}
-		modURI := protocol.URIFromPath(filepath.Join(modDir, "go.mod"))
+		modURI := protocol.URIFromPath(filepath.Join(modDir, "gno.mod"))
 		modFiles[modURI] = unit{}
 	}
 	return modFiles
@@ -62,7 +62,7 @@ func localModFiles(relativeTo string, goWorkOrModPaths []string) map[protocol.Do
 
 // isGoMod reports if uri is a go.mod file.
 func isGoMod(uri protocol.DocumentURI) bool {
-	return filepath.Base(uri.Path()) == "go.mod"
+	return filepath.Base(uri.Path()) == "gno.mod"
 }
 
 // goModModules returns the URIs of "workspace" go.mod files defined by a

--- a/internal/cmd/capabilities_test.go
+++ b/internal/cmd/capabilities_test.go
@@ -35,7 +35,7 @@ func TestCapabilities(t *testing.T) {
 	if err := os.WriteFile(tmpFile, []byte(""), 0775); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module fake\n\ngo 1.12\n"), 0775); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "gno.mod"), []byte("module fake\n\ngo 1.12\n"), 0775); err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)

--- a/internal/doc/api.go
+++ b/internal/doc/api.go
@@ -54,7 +54,7 @@ type EnumValue struct {
 }
 
 type Lens struct {
-	FileType string // e.g. "Go", "go.mod"
+	FileType string // e.g. "Go", "gno.mod"
 	Lens     string
 	Title    string
 	Doc      string

--- a/internal/doc/api.json
+++ b/internal/doc/api.json
@@ -969,28 +969,28 @@
 			"Default": false
 		},
 		{
-			"FileType": "go.mod",
+			"FileType": "gno.mod",
 			"Lens": "run_govulncheck",
 			"Title": "Run govulncheck",
 			"Doc": "\nThis codelens source annotates the `module` directive in a\ngo.mod file with a command to run Govulncheck.\n\n[Govulncheck](https://go.dev/blog/vuln) is a static\nanalysis tool that computes the set of functions reachable\nwithin your application, including dependencies;\nqueries a database of known security vulnerabilities; and\nreports any potential problems it finds.\n",
 			"Default": false
 		},
 		{
-			"FileType": "go.mod",
+			"FileType": "gno.mod",
 			"Lens": "tidy",
 			"Title": "Tidy go.mod file",
 			"Doc": "\nThis codelens source annotates the `module` directive in a\ngo.mod file with a command to run [`go mod\ntidy`](https://go.dev/ref/mod#go-mod-tidy), which ensures\nthat the go.mod file matches the source code in the module.\n",
 			"Default": true
 		},
 		{
-			"FileType": "go.mod",
+			"FileType": "gno.mod",
 			"Lens": "upgrade_dependency",
 			"Title": "Update dependencies",
 			"Doc": "\nThis codelens source annotates the `module` directive in a\ngo.mod file with commands to:\n\n- check for available upgrades,\n- upgrade direct dependencies, and\n- upgrade all dependencies transitively.\n",
 			"Default": true
 		},
 		{
-			"FileType": "go.mod",
+			"FileType": "gno.mod",
 			"Lens": "vendor",
 			"Title": "Update vendor directory",
 			"Doc": "\nThis codelens source annotates the `module` directive in a\ngo.mod file with a command to run [`go mod\nvendor`](https://go.dev/ref/mod#go-mod-vendor), which\ncreates or updates the directory named `vendor` in the\nmodule root so that it contains an up-to-date copy of all\nnecessary package dependencies.\n",

--- a/internal/imports/mod.go
+++ b/internal/imports/mod.go
@@ -509,14 +509,14 @@ func (r *ModuleResolver) modInfo(dir string) (modDir, modName string) {
 		if matches := modCacheRegexp.FindStringSubmatch(dir); len(matches) == 3 {
 			index := strings.Index(dir, matches[1]+"@"+matches[2])
 			modDir := filepath.Join(dir[:index], matches[1]+"@"+matches[2])
-			return modDir, readModName(filepath.Join(modDir, "go.mod"))
+			return modDir, readModName(filepath.Join(modDir, "gno.mod"))
 		}
 	}
 	for {
 		if info, ok := r.cacheLoad(dir); ok {
 			return info.moduleDir, info.moduleName
 		}
-		f := filepath.Join(dir, "go.mod")
+		f := filepath.Join(dir, "gno.mod")
 		info, err := os.Stat(f)
 		if err == nil && !info.IsDir() {
 			return dir, readModName(f)

--- a/internal/imports/mod_cache.go
+++ b/internal/imports/mod_cache.go
@@ -297,7 +297,7 @@ func ScanModuleCache(dir string, cache *DirInfoCache, logf func(string, ...any))
 		importPath := path.Join(modPath, filepath.ToSlash(matches[3]))
 		index := strings.Index(dir, matches[1]+"@"+matches[2])
 		modDir := filepath.Join(dir[:index], matches[1]+"@"+matches[2])
-		modName := readModName(filepath.Join(modDir, "go.mod"))
+		modName := readModName(filepath.Join(modDir, "gno.mod"))
 		return directoryPackageInfo{
 			status:                 directoryScanned,
 			dir:                    dir,

--- a/internal/imports/mod_test.go
+++ b/internal/imports/mod_test.go
@@ -194,10 +194,10 @@ import _ "rsc.io/quote"
 	}
 
 	// Update the go.mod file of example.com so that it changes its module path (not allowed).
-	if err := os.Chmod(filepath.Join(found.dir, "go.mod"), 0644); err != nil {
+	if err := os.Chmod(filepath.Join(found.dir, "gno.mod"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(found.dir, "go.mod"), []byte("module bad.com\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(found.dir, "gno.mod"), []byte("module bad.com\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -205,7 +205,7 @@ import _ "rsc.io/quote"
 	mt.assertScanFinds("rsc.io/quote", "quote")
 
 	// Rewrite the main package so that rsc.io/quote is not in scope.
-	if err := os.WriteFile(filepath.Join(mt.env.WorkingDir, "go.mod"), []byte("module x\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(mt.env.WorkingDir, "gno.mod"), []byte("module x\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(mt.env.WorkingDir, "x.go"), []byte("package x\n"), 0644); err != nil {
@@ -1033,7 +1033,7 @@ func setup(t *testing.T, extraEnv map[string]string, main, wd string) *modTest {
 		env.Logf = log.Printf
 	}
 	// go mod download gets mad if we don't have a go.mod, so make sure we do.
-	_, err = os.Stat(filepath.Join(mainDir, "go.mod"))
+	_, err = os.Stat(filepath.Join(mainDir, "gno.mod"))
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatalf("checking if go.mod exists: %v", err)
 	}

--- a/internal/packages/overlay_test.go
+++ b/internal/packages/overlay_test.go
@@ -564,7 +564,7 @@ func TestOverlayModFileChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(mod1, "go.mod"), []byte(`module mod1
+	if err := os.WriteFile(filepath.Join(mod1, "gno.mod"), []byte(`module mod1
 
 	require (
 		golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
@@ -583,7 +583,7 @@ func TestOverlayModFileChanges(t *testing.T) {
 
 go 1.11
 `
-	if err := os.WriteFile(filepath.Join(mod2, "go.mod"), []byte(want), 0775); err != nil {
+	if err := os.WriteFile(filepath.Join(mod2, "gno.mod"), []byte(want), 0775); err != nil {
 		t.Fatal(err)
 	}
 
@@ -609,7 +609,7 @@ func main() {}
 	}
 
 	// Check that mod2/go.mod has not been modified.
-	got, err := os.ReadFile(filepath.Join(mod2, "go.mod"))
+	got, err := os.ReadFile(filepath.Join(mod2, "gno.mod"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1054,7 +1054,7 @@ func TestOverlaysInReplace(t *testing.T) {
 	if err := os.Mkdir(dirB, 0775); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dirB, "go.mod"), []byte(fmt.Sprintf("module %s.com", dirB)), 0775); err != nil {
+	if err := os.WriteFile(filepath.Join(dirB, "gno.mod"), []byte(fmt.Sprintf("module %s.com", dirB)), 0775); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(filepath.Join(dirB, "inner"), 0775); err != nil {
@@ -1077,7 +1077,7 @@ replace (
 	b.com => %s
 )
 `, dirB)
-	if err := os.WriteFile(filepath.Join(tmpWorkspace, "go.mod"), []byte(goModContent), 0775); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpWorkspace, "gno.mod"), []byte(goModContent), 0775); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/packages/packages_test.go
+++ b/internal/packages/packages_test.go
@@ -2713,8 +2713,8 @@ func testModule(t *testing.T, exporter packagestest.Exporter) {
 		if a.Module.Path != "golang.org/fake" {
 			t.Fatalf("package.Modile.Path: want \"golang.org/fake\", got %q", a.Module.Path)
 		}
-		if a.Module.GoMod != filepath.Join(rootDir, "go.mod") {
-			t.Fatalf("package.Module.GoMod: want %q, got %q", filepath.Join(rootDir, "go.mod"), a.Module.GoMod)
+		if a.Module.GoMod != filepath.Join(rootDir, "gno.mod") {
+			t.Fatalf("package.Module.GoMod: want %q, got %q", filepath.Join(rootDir, "gno.mod"), a.Module.GoMod)
 		}
 	default:
 		t.Fatalf("Expected exporter to be GOPATH or Modules, got %v", exported.Exporter.Name())
@@ -3002,7 +3002,7 @@ func copyAll(srcPath, dstPath string) error {
 		if err != nil {
 			return err
 		}
-		dstFilePath := strings.Replace(filepath.Join(dstPath, rel), "definitelynot_go.mod", "go.mod", -1)
+		dstFilePath := strings.Replace(filepath.Join(dstPath, rel), "definitelynot_go.mod", "gno.mod", -1)
 		if err := os.MkdirAll(filepath.Dir(dstFilePath), 0755); err != nil {
 			return err
 		}
@@ -3080,7 +3080,7 @@ func TestLoadOverlayGoMod(t *testing.T) {
 	cfg := &packages.Config{
 		Mode: packages.LoadSyntax,
 		Overlay: map[string][]byte{
-			filepath.Join(cwd, "go.mod"): []byte("module example.com\ngo 1.0"),
+			filepath.Join(cwd, "gno.mod"): []byte("module example.com\ngo 1.0"),
 		},
 		Env: append(os.Environ(), "GOFLAGS=-mod=vendor", "GOWORK=off"),
 	}

--- a/internal/packages/packagestest/expect.go
+++ b/internal/packages/packagestest/expect.go
@@ -181,7 +181,7 @@ func (e *Exported) getNotes() error {
 	}
 	// Check go.mod markers regardless of mode, we need to do this so that our marker count
 	// matches the counts in the summary.txt.golden file for the test directory.
-	if gomod, found := e.written[e.primary]["go.mod"]; found {
+	if gomod, found := e.written[e.primary]["gno.mod"]; found {
 		// If we are in Modules mode, then we need to check the contents of the go.mod.temp.
 		if e.Exporter == Modules {
 			gomod += ".temp"

--- a/internal/packages/packagestest/export.go
+++ b/internal/packages/packagestest/export.go
@@ -596,7 +596,7 @@ func MustCopyFileTree(root string) map[string]interface{} {
 		if info.IsDir() {
 			// skip nested modules.
 			if path != root {
-				if fi, err := os.Stat(filepath.Join(path, "go.mod")); err == nil && !fi.IsDir() {
+				if fi, err := os.Stat(filepath.Join(path, "gno.mod")); err == nil && !fi.IsDir() {
 					return filepath.SkipDir
 				}
 			}

--- a/internal/packages/packagestest/export_test.go
+++ b/internal/packages/packagestest/export_test.go
@@ -187,7 +187,7 @@ func TestMustCopyFiles(t *testing.T) {
 	// Create the following test directory structure in a temporary directory.
 	src := map[string]string{
 		// copies all files under the specified directory.
-		"go.mod": "module example.com",
+		"gno.mod": "module example.com",
 		"m.go":   "package m",
 		"a/a.go": "package a",
 		// contents from a nested module shouldn't be copied.
@@ -217,7 +217,7 @@ func TestMustCopyFiles(t *testing.T) {
 	for fragment := range copied {
 		got = append(got, filepath.ToSlash(fragment))
 	}
-	want := []string{"go.mod", "m.go", "a/a.go"}
+	want := []string{"gno.mod", "m.go", "a/a.go"}
 
 	sort.Strings(got)
 	sort.Strings(want)

--- a/internal/packages/packagestest/modules.go
+++ b/internal/packages/packagestest/modules.go
@@ -88,7 +88,7 @@ func (modules) Finalize(exported *Exported) error {
 
 	// If the primary module already has a go.mod, write the contents to a temp
 	// go.mod for now and then we will reset it when we are getting all the markers.
-	if gomod := exported.written[exported.primary]["go.mod"]; gomod != "" {
+	if gomod := exported.written[exported.primary]["gno.mod"]; gomod != "" {
 		contents, err := os.ReadFile(gomod)
 		if err != nil {
 			return err
@@ -98,7 +98,7 @@ func (modules) Finalize(exported *Exported) error {
 		}
 	}
 
-	exported.written[exported.primary]["go.mod"] = filepath.Join(primaryDir, "go.mod")
+	exported.written[exported.primary]["gno.mod"] = filepath.Join(primaryDir, "gno.mod")
 	var primaryGomod bytes.Buffer
 	fmt.Fprintf(&primaryGomod, "module %s\nrequire (\n", exported.primary)
 	for other := range exported.written {
@@ -115,7 +115,7 @@ func (modules) Finalize(exported *Exported) error {
 		fmt.Fprintf(&primaryGomod, "\t%v %v\n", other, version)
 	}
 	fmt.Fprintf(&primaryGomod, ")\n")
-	if err := os.WriteFile(filepath.Join(primaryDir, "go.mod"), primaryGomod.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(primaryDir, "gno.mod"), primaryGomod.Bytes(), 0644); err != nil {
 		return err
 	}
 
@@ -130,7 +130,7 @@ func (modules) Finalize(exported *Exported) error {
 			continue
 		}
 		dir := moduleDir(exported, module)
-		modfile := filepath.Join(dir, "go.mod")
+		modfile := filepath.Join(dir, "gno.mod")
 		// If other is of the form `repo1/mod1@v1.1.0`,
 		// then we need to extract the module name without the version.
 		if v, ok := versions[module]; ok {
@@ -139,7 +139,7 @@ func (modules) Finalize(exported *Exported) error {
 		if err := os.WriteFile(modfile, []byte("module "+module+"\n"), 0644); err != nil {
 			return err
 		}
-		files["go.mod"] = modfile
+		files["gno.mod"] = modfile
 	}
 
 	// Zip up all the secondary modules into the proxy dir.

--- a/internal/packages/packagestest/modules_test.go
+++ b/internal/packages/packagestest/modules_test.go
@@ -20,10 +20,10 @@ func TestModulesExport(t *testing.T) {
 		t.Errorf("Got working directory %v expected %v", exported.Config.Dir, expectDir)
 	}
 	checkFiles(t, exported, []fileTest{
-		{"golang.org/fake1", "go.mod", "fake1/go.mod", nil},
+		{"golang.org/fake1", "gno.mod", "fake1/go.mod", nil},
 		{"golang.org/fake1", "a.go", "fake1/a.go", checkLink("testdata/a.go")},
 		{"golang.org/fake1", "b.go", "fake1/b.go", checkContent("package fake1")},
-		{"golang.org/fake2", "go.mod", "modcache/pkg/mod/golang.org/fake2@v1.0.0/go.mod", nil},
+		{"golang.org/fake2", "gno.mod", "modcache/pkg/mod/golang.org/fake2@v1.0.0/go.mod", nil},
 		{"golang.org/fake2", "other/a.go", "modcache/pkg/mod/golang.org/fake2@v1.0.0/other/a.go", checkContent("package fake2")},
 		{"golang.org/fake2/v2", "other/a.go", "modcache/pkg/mod/golang.org/fake2/v2@v2.0.0/other/a.go", checkContent("package fake2")},
 		{"golang.org/fake3@v1.1.0", "other/a.go", "modcache/pkg/mod/golang.org/fake3@v1.1.0/other/a.go", checkContent("package fake3")},

--- a/internal/proxydir/proxydir.go
+++ b/internal/proxydir/proxydir.go
@@ -39,7 +39,7 @@ func WriteModuleVersion(rootDir, module, ver string, files map[string][]byte) (r
 
 	// Serve the go.mod file on the <version>.mod url, if it exists. Otherwise,
 	// serve a stub.
-	modContents, ok := files["go.mod"]
+	modContents, ok := files["gno.mod"]
 	if !ok {
 		modContents = []byte("module " + module)
 	}

--- a/internal/proxydir/proxydir_test.go
+++ b/internal/proxydir/proxydir_test.go
@@ -23,7 +23,7 @@ func TestWriteModuleVersion(t *testing.T) {
 			modulePath: "mod.test/module",
 			version:    "v1.2.3",
 			files: map[string][]byte{
-				"go.mod":   []byte("module mod.com\n\ngo 1.12"),
+				"gno.mod":   []byte("module mod.com\n\ngo 1.12"),
 				"const.go": []byte("package module\n\nconst Answer = 42"),
 			},
 		},
@@ -31,7 +31,7 @@ func TestWriteModuleVersion(t *testing.T) {
 			modulePath: "mod.test/module",
 			version:    "v1.2.4",
 			files: map[string][]byte{
-				"go.mod":   []byte("module mod.com\n\ngo 1.12"),
+				"gno.mod":   []byte("module mod.com\n\ngo 1.12"),
 				"const.go": []byte("package module\n\nconst Answer = 43"),
 			},
 		},
@@ -58,7 +58,7 @@ func TestWriteModuleVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		wantMod, ok := test.files["go.mod"]
+		wantMod, ok := test.files["gno.mod"]
 		if !ok {
 			wantMod = []byte("module " + test.modulePath)
 		}

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -86,10 +86,10 @@ func (h *commandHandler) Modules(ctx context.Context, args command.ModulesArgs) 
 			return false // "can't happen" (see prior Encloses check)
 		}
 
-		assert(filepath.Base(goMod.Path()) == "go.mod", fmt.Sprintf("invalid go.mod path: want go.mod, got %q", goMod.Path()))
+		assert(filepath.Base(goMod.Path()) == "gno.mod", fmt.Sprintf("invalid go.mod path: want go.mod, got %q", goMod.Path()))
 
 		// Invariant: rel is a relative path without "../" segments and the last
-		// segment is "go.mod"
+		// segment is "gno.mod"
 		nparts := strings.Count(rel, string(filepath.Separator))
 		return args.MaxDepth < 0 || nparts <= args.MaxDepth
 	}
@@ -855,7 +855,7 @@ func (c *commandHandler) GoGetPackage(ctx context.Context, args command.GoGetPac
 
 		inv, cleanupInvocation, err := snapshot.GoCommandInvocation(true, &gocommand.Invocation{
 			Verb:       "list",
-			Args:       []string{"-f", "{{.Module.Path}}@{{.Module.Version}}", "-mod=mod", "-modfile=" + filepath.Join(tempDir, "go.mod"), args.Pkg},
+			Args:       []string{"-f", "{{.Module.Path}}@{{.Module.Version}}", "-mod=mod", "-modfile=" + filepath.Join(tempDir, "gno.mod"), args.Pkg},
 			Env:        []string{"GOWORK=off"},
 			WorkingDir: modURI.Dir().Path(),
 		})

--- a/internal/test/integration/codelens/codelens_test.go
+++ b/internal/test/integration/codelens/codelens_test.go
@@ -285,20 +285,20 @@ require golang.org/x/hello v1.3.3
 	).Run(t, shouldUpdateDep, func(t *testing.T, env *Env) {
 		env.RunGoCommand("mod", "vendor")
 		env.AfterChange()
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 
-		env.ExecuteCodeLensCommand("go.mod", command.CheckUpgrades, nil)
+		env.ExecuteCodeLensCommand("gno.mod", command.CheckUpgrades, nil)
 		d := &protocol.PublishDiagnosticsParams{}
 		env.OnceMet(
 			CompletedWork(server.DiagnosticWorkTitle(server.FromCheckUpgrades), 1, true),
-			Diagnostics(env.AtRegexp("go.mod", `require`), WithMessage("can be upgraded")),
-			ReadDiagnostics("go.mod", d),
+			Diagnostics(env.AtRegexp("gno.mod", `require`), WithMessage("can be upgraded")),
+			ReadDiagnostics("gno.mod", d),
 		)
 
 		// Apply the diagnostics to a/go.mod.
-		env.ApplyQuickFixes("go.mod", d.Diagnostics)
+		env.ApplyQuickFixes("gno.mod", d.Diagnostics)
 		env.AfterChange()
-		if got := env.BufferText("go.mod"); got != wantGoModA {
+		if got := env.BufferText("gno.mod"); got != wantGoModA {
 			t.Fatalf("go.mod upgrade failed:\n%s", compare.Text(wantGoModA, got))
 		}
 	})
@@ -349,11 +349,11 @@ func main() {
 }
 `
 	WithOptions(ProxyFiles(proxy)).Run(t, shouldRemoveDep, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
-		env.RegexpReplace("go.mod", "// EOF", "// EOF unsaved edit") // unsaved edits ok
-		env.ExecuteCodeLensCommand("go.mod", command.Tidy, nil)
+		env.OpenFile("gno.mod")
+		env.RegexpReplace("gno.mod", "// EOF", "// EOF unsaved edit") // unsaved edits ok
+		env.ExecuteCodeLensCommand("gno.mod", command.Tidy, nil)
 		env.AfterChange()
-		got := env.BufferText("go.mod")
+		got := env.BufferText("gno.mod")
 		const wantGoMod = `module mod.com
 
 go 1.14

--- a/internal/test/integration/diagnostics/diagnostics_test.go
+++ b/internal/test/integration/diagnostics/diagnostics_test.go
@@ -275,11 +275,11 @@ func Hello() {
 				InitialWorkspaceLoad,
 				Diagnostics(env.AtRegexp("main.go", `"mod.com/bob"`)),
 			)
-			env.CreateBuffer("go.mod", `module mod.com
+			env.CreateBuffer("gno.mod", `module mod.com
 
 	go 1.12
 `)
-			env.SaveBuffer("go.mod")
+			env.SaveBuffer("gno.mod")
 			var d protocol.PublishDiagnosticsParams
 			env.AfterChange(
 				NoDiagnostics(ForFile("main.go")),
@@ -674,7 +674,7 @@ func main() {
 	).Run(t, ardanLabs, func(t *testing.T, env *Env) {
 		// Expect a diagnostic with a suggested fix to add
 		// "github.com/ardanlabs/conf" to the go.mod file.
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		env.OpenFile("main.go")
 		var d protocol.PublishDiagnosticsParams
 		env.AfterChange(
@@ -682,7 +682,7 @@ func main() {
 			ReadDiagnostics("main.go", &d),
 		)
 		env.ApplyQuickFixes("main.go", d.Diagnostics)
-		env.SaveBuffer("go.mod")
+		env.SaveBuffer("gno.mod")
 		env.AfterChange(
 			NoDiagnostics(ForFile("main.go")),
 		)
@@ -696,13 +696,13 @@ func main() {
 		// Expect a diagnostic and fix to remove the dependency in the go.mod.
 		env.AfterChange(
 			NoDiagnostics(ForFile("main.go")),
-			Diagnostics(env.AtRegexp("go.mod", "require github.com/ardanlabs/conf"), WithMessage("not used in this module")),
-			ReadDiagnostics("go.mod", &d),
+			Diagnostics(env.AtRegexp("gno.mod", "require github.com/ardanlabs/conf"), WithMessage("not used in this module")),
+			ReadDiagnostics("gno.mod", &d),
 		)
-		env.ApplyQuickFixes("go.mod", d.Diagnostics)
-		env.SaveBuffer("go.mod")
+		env.ApplyQuickFixes("gno.mod", d.Diagnostics)
+		env.SaveBuffer("gno.mod")
 		env.AfterChange(
-			NoDiagnostics(ForFile("go.mod")),
+			NoDiagnostics(ForFile("gno.mod")),
 		)
 		// Uncomment the lines and expect a new diagnostic for the import.
 		env.RegexpReplace("main.go", "//_ = conf.ErrHelpWanted", "_ = conf.ErrHelpWanted")
@@ -1523,22 +1523,22 @@ go 1.12
 package main
 `
 	Run(t, pkg, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		env.AfterChange(
 			OutstandingWork(server.WorkspaceLoadFailure, "unknown directive"),
 		)
-		env.EditBuffer("go.mod", fake.NewEdit(0, 0, 3, 0, `module mod.com
+		env.EditBuffer("gno.mod", fake.NewEdit(0, 0, 3, 0, `module mod.com
 
 go 1.hello
 `))
 		// As of golang/go#42529, go.mod changes do not reload the workspace until
 		// they are saved.
-		env.SaveBufferWithoutActions("go.mod")
+		env.SaveBufferWithoutActions("gno.mod")
 		env.AfterChange(
 			OutstandingWork(server.WorkspaceLoadFailure, "invalid go version"),
 		)
-		env.RegexpReplace("go.mod", "go 1.hello", "go 1.12")
-		env.SaveBufferWithoutActions("go.mod")
+		env.RegexpReplace("gno.mod", "go 1.hello", "go 1.12")
+		env.SaveBufferWithoutActions("gno.mod")
 		env.AfterChange(
 			NoOutstandingWork(IgnoreTelemetryPromptWork),
 		)
@@ -1860,10 +1860,10 @@ go 1.16
 package main
 `
 	Run(t, files, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		env.Await(env.DoneWithOpen())
-		env.RegexpReplace("go.mod", "module", "modul")
-		env.SaveBufferWithoutActions("go.mod")
+		env.RegexpReplace("gno.mod", "module", "modul")
+		env.SaveBufferWithoutActions("gno.mod")
 		env.AfterChange(
 			NoLogMatching(protocol.Error, "initial workspace load failed"),
 		)
@@ -1884,7 +1884,7 @@ package main
 func main() {}
 `
 	Run(t, files, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		env.Await(
 			// Check that we have only loaded "<dir>/..." once.
 			// Log messages are asynchronous to other events on the LSP stream, so we
@@ -1910,7 +1910,7 @@ const C = 0b10
 			InitialWorkspaceLoad,
 			Diagnostics(env.AtRegexp("main.go", `0b10`), WithMessage("go1.13 or later")),
 		)
-		env.WriteWorkspaceFile("go.mod", "module mod.com \n\ngo 1.13\n")
+		env.WriteWorkspaceFile("gno.mod", "module mod.com \n\ngo 1.13\n")
 		env.AfterChange(
 			NoDiagnostics(ForFile("main.go")),
 		)

--- a/internal/test/integration/fake/editor.go
+++ b/internal/test/integration/fake/editor.go
@@ -110,7 +110,7 @@ type EditorConfig struct {
 	// Map of language ID -> regexp to match, used to set the file type of new
 	// buffers. Applied as an overlay on top of the following defaults:
 	//  "go" -> ".*\.go"
-	//  "go.mod" -> "go\.mod"
+	//  "gno.mod" -> "go\.mod"
 	//  "go.sum" -> "go\.sum"
 	//  "gotmpl" -> ".*tmpl"
 	FileAssociations map[string]string
@@ -583,7 +583,7 @@ func (e *Editor) sendDidOpen(ctx context.Context, item protocol.TextDocumentItem
 
 var defaultFileAssociations = map[string]*regexp.Regexp{
 	"go":      regexp.MustCompile(`^.*\.go$`), // '$' is important: don't match .gotmpl!
-	"go.mod":  regexp.MustCompile(`^go\.mod$`),
+	"gno.mod":  regexp.MustCompile(`^go\.mod$`),
 	"go.sum":  regexp.MustCompile(`^go(\.work)?\.sum$`),
 	"go.work": regexp.MustCompile(`^go\.work$`),
 	"gotmpl":  regexp.MustCompile(`^.*tmpl$`),

--- a/internal/test/integration/fake/workdir_test.go
+++ b/internal/test/integration/fake/workdir_test.go
@@ -182,10 +182,10 @@ func TestWorkdir_CheckForFileChanges(t *testing.T) {
 		}
 	}
 	// Sleep some positive amount of time to ensure a distinct mtime.
-	if err := writeFileData("go.mod", []byte("module foo.test\n"), wd.RelativeTo); err != nil {
+	if err := writeFileData("gno.mod", []byte("module foo.test\n"), wd.RelativeTo); err != nil {
 		t.Fatal(err)
 	}
-	checkChange("go.mod", protocol.Changed)
+	checkChange("gno.mod", protocol.Changed)
 	if err := writeFileData("newFile", []byte("something"), wd.RelativeTo); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/test/integration/misc/hover_test.go
+++ b/internal/test/integration/misc/hover_test.go
@@ -276,8 +276,8 @@ func TestHoverModMissingModuleStmt(t *testing.T) {
 go 1.16
 `
 	Run(t, source, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
-		env.Hover(env.RegexpSearch("go.mod", "go")) // no panic
+		env.OpenFile("gno.mod")
+		env.Hover(env.RegexpSearch("gno.mod", "go")) // no panic
 	})
 }
 

--- a/internal/test/integration/misc/link_test.go
+++ b/internal/test/integration/misc/link_test.go
@@ -45,7 +45,7 @@ const Hello = "Hello"
 		WriteGoSum("."),
 	).Run(t, program, func(t *testing.T, env *Env) {
 		env.OpenFile("main.go")
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 
 		modLink := "https://pkg.go.dev/mod/import.test@v1.2.3"
 		pkgLink := "https://pkg.go.dev/import.test@v1.2.3/pkg"
@@ -55,7 +55,7 @@ const Hello = "Hello"
 		if content == nil || !strings.Contains(content.Value, pkgLink) {
 			t.Errorf("hover: got %v in main.go, want contains %q", content, pkgLink)
 		}
-		content, _ = env.Hover(env.RegexpSearch("go.mod", "import.test"))
+		content, _ = env.Hover(env.RegexpSearch("gno.mod", "import.test"))
 		if content == nil || !strings.Contains(content.Value, pkgLink) {
 			t.Errorf("hover: got %v in go.mod, want contains %q", content, pkgLink)
 		}
@@ -63,7 +63,7 @@ const Hello = "Hello"
 		if len(links) != 1 || *links[0].Target != pkgLink {
 			t.Errorf("documentLink: got links %+v for main.go, want one link with target %q", links, pkgLink)
 		}
-		links = env.DocumentLink("go.mod")
+		links = env.DocumentLink("gno.mod")
 		if len(links) != 1 || *links[0].Target != modLink {
 			t.Errorf("documentLink: got links %+v for go.mod, want one link with target %q", links, modLink)
 		}
@@ -78,7 +78,7 @@ const Hello = "Hello"
 		if content == nil || strings.Contains(content.Value, pkgLink) {
 			t.Errorf("hover: got %v in main.go, want non-empty hover without %q", content, pkgLink)
 		}
-		content, _ = env.Hover(env.RegexpSearch("go.mod", "import.test"))
+		content, _ = env.Hover(env.RegexpSearch("gno.mod", "import.test"))
 		if content == nil || strings.Contains(content.Value, modLink) {
 			t.Errorf("hover: got %v in go.mod, want contains %q", content, modLink)
 		}
@@ -86,7 +86,7 @@ const Hello = "Hello"
 		if len(links) != 0 {
 			t.Errorf("documentLink: got %d document links for main.go, want 0\nlinks: %v", len(links), links)
 		}
-		links = env.DocumentLink("go.mod")
+		links = env.DocumentLink("gno.mod")
 		if len(links) != 0 {
 			t.Errorf("documentLink: got %d document links for go.mod, want 0\nlinks: %v", len(links), links)
 		}

--- a/internal/test/integration/misc/rename_test.go
+++ b/internal/test/integration/misc/rename_test.go
@@ -561,8 +561,8 @@ func main() {
 		env.RegexpSearch("main.go", "mod.com/foox")
 		env.RegexpSearch("main.go", "foox.Bar()")
 
-		env.RegexpSearch("go.mod", "./foox/bar")
-		env.RegexpSearch("go.mod", "./foox/baz")
+		env.RegexpSearch("gno.mod", "./foox/bar")
+		env.RegexpSearch("gno.mod", "./foox/baz")
 	})
 }
 

--- a/internal/test/integration/misc/vendor_test.go
+++ b/internal/test/integration/misc/vendor_test.go
@@ -52,10 +52,10 @@ func _() {
 		env.OpenFile("a/a1.go")
 		d := &protocol.PublishDiagnosticsParams{}
 		env.AfterChange(
-			Diagnostics(env.AtRegexp("go.mod", "module mod.com"), WithMessage("Inconsistent vendoring")),
-			ReadDiagnostics("go.mod", d),
+			Diagnostics(env.AtRegexp("gno.mod", "module mod.com"), WithMessage("Inconsistent vendoring")),
+			ReadDiagnostics("gno.mod", d),
 		)
-		env.ApplyQuickFixes("go.mod", d.Diagnostics)
+		env.ApplyQuickFixes("gno.mod", d.Diagnostics)
 
 		env.AfterChange(
 			Diagnostics(env.AtRegexp("a/a1.go", `q int`), WithMessage("not used")),

--- a/internal/test/integration/misc/vuln_test.go
+++ b/internal/test/integration/misc/vuln_test.go
@@ -70,9 +70,9 @@ func F() { // build error incomplete
 			},
 		},
 	).Run(t, files, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		var result command.RunVulncheckResult
-		env.ExecuteCodeLensCommand("go.mod", command.RunGovulncheck, &result)
+		env.ExecuteCodeLensCommand("gno.mod", command.RunGovulncheck, &result)
 		var ws WorkStatus
 		env.Await(
 			CompletedProgress(result.Token, &ws),
@@ -196,19 +196,19 @@ func main() {
 			},
 		},
 	).Run(t, files, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 
 		// Run Command included in the codelens.
 		var result command.RunVulncheckResult
-		env.ExecuteCodeLensCommand("go.mod", command.RunGovulncheck, &result)
+		env.ExecuteCodeLensCommand("gno.mod", command.RunGovulncheck, &result)
 
 		env.OnceMet(
 			CompletedProgress(result.Token, nil),
 			ShownMessage("Found GOSTDLIB"),
-			NoDiagnostics(ForFile("go.mod")),
+			NoDiagnostics(ForFile("gno.mod")),
 		)
 		testFetchVulncheckResult(t, env, map[string]fetchVulncheckResult{
-			"go.mod": {IDs: []string{"GOSTDLIB"}, Mode: vulncheck.ModeGovulncheck}})
+			"gno.mod": {IDs: []string{"GOSTDLIB"}, Mode: vulncheck.ModeGovulncheck}})
 	})
 }
 func TestFetchVulncheckResultStd(t *testing.T) {
@@ -247,13 +247,13 @@ func main() {
 		},
 		Settings{"ui.diagnostic.vulncheck": "Imports"},
 	).Run(t, files, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		env.AfterChange(
-			NoDiagnostics(ForFile("go.mod")),
+			NoDiagnostics(ForFile("gno.mod")),
 			// we don't publish diagnostics for standard library vulnerability yet.
 		)
 		testFetchVulncheckResult(t, env, map[string]fetchVulncheckResult{
-			"go.mod": {
+			"gno.mod": {
 				IDs:  []string{"GOSTDLIB"},
 				Mode: vulncheck.ModeImports,
 			},
@@ -271,7 +271,7 @@ func testFetchVulncheckResult(t *testing.T, env *Env, want map[string]fetchVulnc
 
 	var result map[protocol.DocumentURI]*vulncheck.Result
 	fetchCmd := command.NewFetchVulncheckResultCommand("fetch", command.URIArg{
-		URI: env.Sandbox.Workdir.URI("go.mod"),
+		URI: env.Sandbox.Workdir.URI("gno.mod"),
 	})
 	env.ExecuteCommand(&protocol.ExecuteCommandParams{
 		Command:   fetchCmd.Command,
@@ -455,16 +455,16 @@ func TestRunVulncheckPackageDiagnostics(t *testing.T) {
 	defer db.Clean()
 
 	checkVulncheckDiagnostics := func(env *Env, t *testing.T) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 
 		gotDiagnostics := &protocol.PublishDiagnosticsParams{}
 		env.AfterChange(
-			Diagnostics(env.AtRegexp("go.mod", `golang.org/amod`)),
-			ReadDiagnostics("go.mod", gotDiagnostics),
+			Diagnostics(env.AtRegexp("gno.mod", `golang.org/amod`)),
+			ReadDiagnostics("gno.mod", gotDiagnostics),
 		)
 
 		testFetchVulncheckResult(t, env, map[string]fetchVulncheckResult{
-			"go.mod": {
+			"gno.mod": {
 				IDs:  []string{"GO-2022-01", "GO-2022-02", "GO-2022-03"},
 				Mode: vulncheck.ModeImports,
 			},
@@ -512,7 +512,7 @@ func TestRunVulncheckPackageDiagnostics(t *testing.T) {
 		for pattern, want := range wantVulncheckDiagnostics {
 			modPathDiagnostics := testVulnDiagnostics(t, env, pattern, want, gotDiagnostics)
 
-			gotActions := env.CodeActionForFile("go.mod", modPathDiagnostics)
+			gotActions := env.CodeActionForFile("gno.mod", modPathDiagnostics)
 			if diff := diffCodeActions(gotActions, want.codeActions); diff != "" {
 				t.Errorf("code actions for %q do not match, got %v, want %v\n%v\n", pattern, gotActions, want.codeActions, diff)
 				continue
@@ -521,11 +521,11 @@ func TestRunVulncheckPackageDiagnostics(t *testing.T) {
 	}
 
 	wantNoVulncheckDiagnostics := func(env *Env, t *testing.T) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 
 		gotDiagnostics := &protocol.PublishDiagnosticsParams{}
 		env.AfterChange(
-			ReadDiagnostics("go.mod", gotDiagnostics),
+			ReadDiagnostics("gno.mod", gotDiagnostics),
 		)
 
 		if len(gotDiagnostics.Diagnostics) > 0 {
@@ -558,15 +558,15 @@ func TestRunVulncheckPackageDiagnostics(t *testing.T) {
 				if tc.name == "imports" && tc.wantDiagnostics {
 					// test we get only govulncheck-based diagnostics after "run govulncheck".
 					var result command.RunVulncheckResult
-					env.ExecuteCodeLensCommand("go.mod", command.RunGovulncheck, &result)
+					env.ExecuteCodeLensCommand("gno.mod", command.RunGovulncheck, &result)
 					gotDiagnostics := &protocol.PublishDiagnosticsParams{}
 					env.OnceMet(
 						CompletedProgress(result.Token, nil),
 						ShownMessage("Found"),
 					)
 					env.OnceMet(
-						Diagnostics(env.AtRegexp("go.mod", "golang.org/bmod")),
-						ReadDiagnostics("go.mod", gotDiagnostics),
+						Diagnostics(env.AtRegexp("gno.mod", "golang.org/bmod")),
+						ReadDiagnostics("gno.mod", gotDiagnostics),
 					)
 					// We expect only one diagnostic for GO-2022-02.
 					count := 0
@@ -603,11 +603,11 @@ func TestRunGovulncheck_Expiry(t *testing.T) {
 	defer db.Clean()
 
 	WithOptions(opts0...).Run(t, workspace1, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		env.OpenFile("x/x.go")
 
 		var result command.RunVulncheckResult
-		env.ExecuteCodeLensCommand("go.mod", command.RunGovulncheck, &result)
+		env.ExecuteCodeLensCommand("gno.mod", command.RunGovulncheck, &result)
 		env.OnceMet(
 			CompletedProgress(result.Token, nil),
 			ShownMessage("Found"),
@@ -617,7 +617,7 @@ func TestRunGovulncheck_Expiry(t *testing.T) {
 		// Make an arbitrary edit to force re-diagnosis of the workspace.
 		env.RegexpReplace("x/x.go", "package x", "package x ")
 		env.AfterChange(
-			NoDiagnostics(env.AtRegexp("go.mod", "golang.org/bmod")),
+			NoDiagnostics(env.AtRegexp("gno.mod", "golang.org/bmod")),
 		)
 	})
 }
@@ -634,10 +634,10 @@ func TestRunVulncheckWarning(t *testing.T) {
 	}
 	defer db.Clean()
 	WithOptions(opts...).Run(t, workspace1, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 
 		var result command.RunVulncheckResult
-		env.ExecuteCodeLensCommand("go.mod", command.RunGovulncheck, &result)
+		env.ExecuteCodeLensCommand("gno.mod", command.RunGovulncheck, &result)
 		gotDiagnostics := &protocol.PublishDiagnosticsParams{}
 		env.OnceMet(
 			CompletedProgress(result.Token, nil),
@@ -645,13 +645,13 @@ func TestRunVulncheckWarning(t *testing.T) {
 		)
 		// Vulncheck diagnostics asynchronous to the vulncheck command.
 		env.OnceMet(
-			Diagnostics(env.AtRegexp("go.mod", `golang.org/amod`)),
-			ReadDiagnostics("go.mod", gotDiagnostics),
+			Diagnostics(env.AtRegexp("gno.mod", `golang.org/amod`)),
+			ReadDiagnostics("gno.mod", gotDiagnostics),
 		)
 
 		testFetchVulncheckResult(t, env, map[string]fetchVulncheckResult{
 			// All vulnerabilities (symbol-level, import-level, module-level) are reported.
-			"go.mod": {IDs: []string{"GO-2022-01", "GO-2022-02", "GO-2022-03", "GO-2022-04"}, Mode: vulncheck.ModeGovulncheck},
+			"gno.mod": {IDs: []string{"GO-2022-01", "GO-2022-02", "GO-2022-03", "GO-2022-04"}, Mode: vulncheck.ModeGovulncheck},
 		})
 		env.OpenFile("x/x.go")
 		env.OpenFile("y/y.go")
@@ -709,7 +709,7 @@ func TestRunVulncheckWarning(t *testing.T) {
 			modPathDiagnostics := testVulnDiagnostics(t, env, mod, want, gotDiagnostics)
 
 			// Check that the actions we get when including all diagnostics at a location return the same result
-			gotActions := env.CodeActionForFile("go.mod", modPathDiagnostics)
+			gotActions := env.CodeActionForFile("gno.mod", modPathDiagnostics)
 			if diff := diffCodeActions(gotActions, want.codeActions); diff != "" {
 				t.Errorf("code actions for %q do not match, expected %v, got %v\n%v\n", mod, want.codeActions, gotActions, diff)
 				continue
@@ -739,7 +739,7 @@ require (
 	golang.org/bmod v0.5.0 // indirect
 )
 `
-		if got := env.BufferText("go.mod"); got != wantGoMod {
+		if got := env.BufferText("gno.mod"); got != wantGoMod {
 			t.Fatalf("go.mod vulncheck fix failed:\n%s", compare.Text(wantGoMod, got))
 		}
 	})
@@ -790,9 +790,9 @@ func TestGovulncheckInfo(t *testing.T) {
 	}
 	defer db.Clean()
 	WithOptions(opts...).Run(t, workspace2, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		var result command.RunVulncheckResult
-		env.ExecuteCodeLensCommand("go.mod", command.RunGovulncheck, &result)
+		env.ExecuteCodeLensCommand("gno.mod", command.RunGovulncheck, &result)
 		gotDiagnostics := &protocol.PublishDiagnosticsParams{}
 		env.OnceMet(
 			CompletedProgress(result.Token, nil),
@@ -801,11 +801,11 @@ func TestGovulncheckInfo(t *testing.T) {
 
 		// Vulncheck diagnostics asynchronous to the vulncheck command.
 		env.OnceMet(
-			Diagnostics(env.AtRegexp("go.mod", "golang.org/bmod")),
-			ReadDiagnostics("go.mod", gotDiagnostics),
+			Diagnostics(env.AtRegexp("gno.mod", "golang.org/bmod")),
+			ReadDiagnostics("gno.mod", gotDiagnostics),
 		)
 
-		testFetchVulncheckResult(t, env, map[string]fetchVulncheckResult{"go.mod": {IDs: []string{"GO-2022-02", "GO-2022-04"}, Mode: vulncheck.ModeGovulncheck}})
+		testFetchVulncheckResult(t, env, map[string]fetchVulncheckResult{"gno.mod": {IDs: []string{"GO-2022-02", "GO-2022-04"}, Mode: vulncheck.ModeGovulncheck}})
 		// wantDiagnostics maps a module path in the require
 		// section of a go.mod to diagnostics that will be returned
 		// when running vulncheck.
@@ -832,7 +832,7 @@ func TestGovulncheckInfo(t *testing.T) {
 		for mod, want := range wantDiagnostics {
 			modPathDiagnostics := testVulnDiagnostics(t, env, mod, want, gotDiagnostics)
 			// Check that the actions we get when including all diagnostics at a location return the same result
-			gotActions := env.CodeActionForFile("go.mod", modPathDiagnostics)
+			gotActions := env.CodeActionForFile("gno.mod", modPathDiagnostics)
 			allActions = append(allActions, gotActions...)
 			if diff := diffCodeActions(gotActions, want.codeActions); diff != "" {
 				t.Errorf("code actions for %q do not match, expected %v, got %v\n%v\n", mod, want.codeActions, gotActions, diff)
@@ -853,7 +853,7 @@ func TestGovulncheckInfo(t *testing.T) {
 		}
 		env.ApplyCodeAction(reset)
 
-		env.Await(NoDiagnostics(ForFile("go.mod")))
+		env.Await(NoDiagnostics(ForFile("gno.mod")))
 	})
 }
 
@@ -861,7 +861,7 @@ func TestGovulncheckInfo(t *testing.T) {
 // and runs checks if diagnostics and code actions associated with the line match expectation.
 func testVulnDiagnostics(t *testing.T, env *Env, pattern string, want vulnDiagExpectation, got *protocol.PublishDiagnosticsParams) []protocol.Diagnostic {
 	t.Helper()
-	loc := env.RegexpSearch("go.mod", pattern)
+	loc := env.RegexpSearch("gno.mod", pattern)
 	var modPathDiagnostics []protocol.Diagnostic
 	for _, w := range want.diagnostics {
 		// Find the diagnostics at loc.start.
@@ -882,7 +882,7 @@ func testVulnDiagnostics(t *testing.T, env *Env, pattern string, want vulnDiagEx
 			t.Errorf("incorrect (severity, source) for %q, want (%s, %s) got (%s, %s)\n", w.msg, w.severity, w.source, diag.Severity, diag.Source)
 		}
 		// Check expected code actions appear.
-		gotActions := env.CodeActionForFile("go.mod", []protocol.Diagnostic{*diag})
+		gotActions := env.CodeActionForFile("gno.mod", []protocol.Diagnostic{*diag})
 		if diff := diffCodeActions(gotActions, w.codeActions); diff != "" {
 			t.Errorf("code actions for %q do not match, want %v, got %v\n%v\n", w.msg, w.codeActions, gotActions, diff)
 			continue

--- a/internal/test/integration/modfile/modfile_test.go
+++ b/internal/test/integration/modfile/modfile_test.go
@@ -683,11 +683,11 @@ func main() {
 		Modes(Default),
 	).Run(t, mod, func(t *testing.T, env *Env) {
 		env.OpenFile("main.go")
-		original := env.ReadWorkspaceFile("go.mod")
+		original := env.ReadWorkspaceFile("gno.mod")
 		env.AfterChange(
 			Diagnostics(env.AtRegexp("main.go", `"example.com/blah"`)),
 		)
-		got := env.ReadWorkspaceFile("go.mod")
+		got := env.ReadWorkspaceFile("gno.mod")
 		if got != original {
 			t.Fatalf("go.mod file modified:\n%s", compare.Text(original, got))
 		}
@@ -790,10 +790,10 @@ package main
 func main() {}
 `
 	Run(t, mod, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
-		env.RegexpReplace("go.mod", "module", "modul")
+		env.OpenFile("gno.mod")
+		env.RegexpReplace("gno.mod", "module", "modul")
 		env.AfterChange(
-			Diagnostics(env.AtRegexp("go.mod", "modul")),
+			Diagnostics(env.AtRegexp("gno.mod", "modul")),
 		)
 	})
 }
@@ -824,18 +824,18 @@ func main() {
 		ProxyFiles(workspaceProxy),
 	).Run(t, mod, func(t *testing.T, env *Env) {
 		d := &protocol.PublishDiagnosticsParams{}
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		env.AfterChange(
 			Diagnostics(
-				env.AtRegexp("go.mod", `example.com v1.2.3`),
+				env.AtRegexp("gno.mod", `example.com v1.2.3`),
 				WithMessage("go.sum is out of sync"),
 			),
-			ReadDiagnostics("go.mod", d),
+			ReadDiagnostics("gno.mod", d),
 		)
-		env.ApplyQuickFixes("go.mod", d.Diagnostics)
-		env.SaveBuffer("go.mod") // Save to trigger diagnostics.
+		env.ApplyQuickFixes("gno.mod", d.Diagnostics)
+		env.SaveBuffer("gno.mod") // Save to trigger diagnostics.
 		env.AfterChange(
-			NoDiagnostics(ForFile("go.mod")),
+			NoDiagnostics(ForFile("gno.mod")),
 		)
 	})
 }
@@ -865,9 +865,9 @@ func hello() {}
 		// exercise the workspace module.
 		Modes(Default),
 	).Run(t, mod, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		env.Await(env.DoneWithOpen())
-		env.RegexpReplace("go.mod", "module", "modul")
+		env.RegexpReplace("gno.mod", "module", "modul")
 		// Confirm that we still have metadata with only on-disk edits.
 		env.OpenFile("main.go")
 		loc := env.GoToDefinition(env.RegexpSearch("main.go", "hello"))
@@ -875,7 +875,7 @@ func hello() {}
 			t.Fatalf("expected definition in hello.go, got %s", loc.URI)
 		}
 		// Confirm that we no longer have metadata when the file is saved.
-		env.SaveBufferWithoutActions("go.mod")
+		env.SaveBufferWithoutActions("gno.mod")
 		_, err := env.Editor.Definition(env.Ctx, env.RegexpSearch("main.go", "hello"))
 		if err == nil {
 			t.Fatalf("expected error, got none")
@@ -931,18 +931,18 @@ func main() {}
 		WithOptions(
 			ProxyFiles(proxy),
 		).Run(t, mod, func(t *testing.T, env *Env) {
-			env.OpenFile("go.mod")
+			env.OpenFile("gno.mod")
 			d := &protocol.PublishDiagnosticsParams{}
 			env.AfterChange(
-				Diagnostics(env.AtRegexp("go.mod", "require hasdep.com v1.2.3")),
-				ReadDiagnostics("go.mod", d),
+				Diagnostics(env.AtRegexp("gno.mod", "require hasdep.com v1.2.3")),
+				ReadDiagnostics("gno.mod", d),
 			)
 			const want = `module mod.com
 
 go 1.12
 `
-			env.ApplyQuickFixes("go.mod", d.Diagnostics)
-			if got := env.BufferText("go.mod"); got != want {
+			env.ApplyQuickFixes("gno.mod", d.Diagnostics)
+			if got := env.BufferText("gno.mod"); got != want {
 				t.Fatalf("unexpected content in go.mod:\n%s", compare.Text(want, got))
 			}
 		})
@@ -973,11 +973,11 @@ func main() {}
 			ProxyFiles(proxy),
 		).Run(t, mod, func(t *testing.T, env *Env) {
 			d := &protocol.PublishDiagnosticsParams{}
-			env.OpenFile("go.mod")
-			pos := env.RegexpSearch("go.mod", "require hasdep.com v1.2.3").Range.Start
+			env.OpenFile("gno.mod")
+			pos := env.RegexpSearch("gno.mod", "require hasdep.com v1.2.3").Range.Start
 			env.AfterChange(
-				Diagnostics(AtPosition("go.mod", pos.Line, pos.Character)),
-				ReadDiagnostics("go.mod", d),
+				Diagnostics(AtPosition("gno.mod", pos.Line, pos.Character)),
+				ReadDiagnostics("gno.mod", d),
 			)
 			const want = `module mod.com
 
@@ -992,8 +992,8 @@ require random.com v1.2.3
 				}
 				diagnostics = append(diagnostics, d)
 			}
-			env.ApplyQuickFixes("go.mod", diagnostics)
-			if got := env.BufferText("go.mod"); got != want {
+			env.ApplyQuickFixes("gno.mod", diagnostics)
+			if got := env.BufferText("gno.mod"); got != want {
 				t.Fatalf("unexpected content in go.mod:\n%s", compare.Text(want, got))
 			}
 		})
@@ -1026,16 +1026,16 @@ func main() {
 		ProxyFiles(workspaceProxy),
 		Modes(Default),
 	).Run(t, mod, func(t *testing.T, env *Env) {
-		env.OpenFile("go.mod")
+		env.OpenFile("gno.mod")
 		params := &protocol.PublishDiagnosticsParams{}
 		env.AfterChange(
 			Diagnostics(
-				env.AtRegexp("go.mod", `example.com`),
+				env.AtRegexp("gno.mod", `example.com`),
 				WithMessage("go.sum is out of sync"),
 			),
-			ReadDiagnostics("go.mod", params),
+			ReadDiagnostics("gno.mod", params),
 		)
-		env.ApplyQuickFixes("go.mod", params.Diagnostics)
+		env.ApplyQuickFixes("gno.mod", params.Diagnostics)
 		const want = `example.com v1.2.3 h1:Yryq11hF02fEf2JlOS2eph+ICE2/ceevGV3C9dl5V/c=
 example.com v1.2.3/go.mod h1:Y2Rc5rVWjWur0h3pd9aEvK5Pof8YKDANh9gHA2Maujo=
 `
@@ -1106,7 +1106,7 @@ func main() {
 		env.ApplyQuickFixes("main.go", d.Diagnostics)
 		env.AfterChange(
 			NoDiagnostics(ForFile("main.go")),
-			NoDiagnostics(ForFile("go.mod")),
+			NoDiagnostics(ForFile("gno.mod")),
 		)
 	})
 }
@@ -1123,10 +1123,10 @@ package main
 	Run(t, files, func(t *testing.T, env *Env) {
 		env.OnceMet(
 			InitialWorkspaceLoad,
-			Diagnostics(env.AtRegexp("go.mod", `go foo`), WithMessage("invalid go version")),
+			Diagnostics(env.AtRegexp("gno.mod", `go foo`), WithMessage("invalid go version")),
 		)
-		env.WriteWorkspaceFile("go.mod", "module mod.com \n\ngo 1.12\n")
-		env.AfterChange(NoDiagnostics(ForFile("go.mod")))
+		env.WriteWorkspaceFile("gno.mod", "module mod.com \n\ngo 1.12\n")
+		env.AfterChange(NoDiagnostics(ForFile("gno.mod")))
 	})
 }
 

--- a/internal/test/integration/modfile/tempmodfile_test.go
+++ b/internal/test/integration/modfile/tempmodfile_test.go
@@ -33,7 +33,7 @@ package p
 		env.OpenFile("p.go")
 		env.AfterChange()
 		want := "module badmod.test/p\n"
-		got := env.ReadWorkspaceFile("go.mod")
+		got := env.ReadWorkspaceFile("gno.mod")
 		if got != want {
 			t.Errorf("go.mod content:\n%s\nwant:\n%s", got, want)
 		}

--- a/internal/test/integration/watch/watch_test.go
+++ b/internal/test/integration/watch/watch_test.go
@@ -539,7 +539,7 @@ func main() {
 `
 	WithOptions(ProxyFiles(proxy)).Run(t, mod, func(t *testing.T, env *Env) {
 		env.WriteWorkspaceFiles(map[string]string{
-			"go.mod": `module mod.com
+			"gno.mod": `module mod.com
 
 go 1.12
 

--- a/internal/test/integration/workspace/broken_test.go
+++ b/internal/test/integration/workspace/broken_test.go
@@ -162,9 +162,9 @@ const F = named.D - 3
 		env.AfterChange(
 			Diagnostics(env.AtRegexp("p/internal/bar/bar.go", "\"mod.test/p/internal/foo\"")),
 		)
-		env.OpenFile("go.mod")
-		env.RegexpReplace("go.mod", "mod.testx", "mod.test")
-		env.SaveBuffer("go.mod") // saving triggers a reload
+		env.OpenFile("gno.mod")
+		env.RegexpReplace("gno.mod", "mod.testx", "mod.test")
+		env.SaveBuffer("gno.mod") // saving triggers a reload
 		env.AfterChange(NoDiagnostics())
 	})
 }

--- a/internal/test/integration/workspace/modules_test.go
+++ b/internal/test/integration/workspace/modules_test.go
@@ -63,7 +63,7 @@ func Bar()
 				checkModules(t, env, env.Editor.DocumentURI(""), -1, []command.Module{
 					{
 						Path:  "foo",
-						GoMod: env.Editor.DocumentURI("go.mod"),
+						GoMod: env.Editor.DocumentURI("gno.mod"),
 					},
 				})
 			})
@@ -80,7 +80,7 @@ func Bar()
 					},
 					{
 						Path:  "foo",
-						GoMod: env.Editor.DocumentURI("go.mod"),
+						GoMod: env.Editor.DocumentURI("gno.mod"),
 					},
 				})
 			})
@@ -93,7 +93,7 @@ func Bar()
 				checkModules(t, env, env.Editor.DocumentURI(""), 1, []command.Module{
 					{
 						Path:  "foo",
-						GoMod: env.Editor.DocumentURI("go.mod"),
+						GoMod: env.Editor.DocumentURI("gno.mod"),
 					},
 				})
 			})

--- a/internal/test/integration/workspace/packages_test.go
+++ b/internal/test/integration/workspace/packages_test.go
@@ -46,7 +46,7 @@ func Baz()
 			}, map[string]command.Module{
 				"foo": {
 					Path:  "foo",
-					GoMod: env.Editor.DocumentURI("go.mod"),
+					GoMod: env.Editor.DocumentURI("gno.mod"),
 				},
 			}, []string{})
 		})
@@ -62,7 +62,7 @@ func Baz()
 			}, map[string]command.Module{
 				"foo": {
 					Path:  "foo",
-					GoMod: env.Editor.DocumentURI("go.mod"),
+					GoMod: env.Editor.DocumentURI("gno.mod"),
 				},
 			}, []string{})
 		})
@@ -82,7 +82,7 @@ func Baz()
 			}, map[string]command.Module{
 				"foo": {
 					Path:  "foo",
-					GoMod: env.Editor.DocumentURI("go.mod"),
+					GoMod: env.Editor.DocumentURI("gno.mod"),
 				},
 			}, []string{})
 		})
@@ -183,7 +183,7 @@ func Test(*testing.T)
 			}, map[string]command.Module{
 				"foo": {
 					Path:  "foo",
-					GoMod: env.Editor.DocumentURI("go.mod"),
+					GoMod: env.Editor.DocumentURI("gno.mod"),
 				},
 			}, []string{
 				"func TestFoo(t *testing.T)",
@@ -214,7 +214,7 @@ func Test(*testing.T)
 			}, map[string]command.Module{
 				"foo": {
 					Path:  "foo",
-					GoMod: env.Editor.DocumentURI("go.mod"),
+					GoMod: env.Editor.DocumentURI("gno.mod"),
 				},
 			}, []string{
 				"func TestBaz(*testing.T)",
@@ -277,7 +277,7 @@ func Test(*testing.T)
 			}, map[string]command.Module{
 				"foo": {
 					Path:  "foo",
-					GoMod: env.Editor.DocumentURI("go.mod"),
+					GoMod: env.Editor.DocumentURI("gno.mod"),
 				},
 			}, []string{
 				"func TestFoo(t *testing.T)",
@@ -392,7 +392,7 @@ func (X) SubtestMethod(t *testing.T) {
 		}, map[string]command.Module{
 			"foo": {
 				Path:  "foo",
-				GoMod: env.Editor.DocumentURI("go.mod"),
+				GoMod: env.Editor.DocumentURI("gno.mod"),
 			},
 		}, []string{
 			"func ExampleFoo() {}",

--- a/internal/test/integration/workspace/workspace_test.go
+++ b/internal/test/integration/workspace/workspace_test.go
@@ -1023,7 +1023,7 @@ func main() {
 		env.OpenFile("b/go.mod")
 		env.AfterChange(
 			Diagnostics(
-				env.AtRegexp("go.mod", `example.com v1.2.3`),
+				env.AtRegexp("gno.mod", `example.com v1.2.3`),
 				WithMessage("go.sum is out of sync"),
 			),
 			ReadDiagnostics("b/go.mod", params),

--- a/internal/test/integration/workspace/zero_config_test.go
+++ b/internal/test/integration/workspace/zero_config_test.go
@@ -182,7 +182,7 @@ const C = 0
 	Run(t, files, func(t *testing.T, env *Env) {
 		env.OpenFile("a.go")
 		env.AfterChange(
-			Diagnostics(env.AtRegexp("go.mod", "modul")),
+			Diagnostics(env.AtRegexp("gno.mod", "modul")),
 			Diagnostics(env.AtRegexp("a.go", "broken"), WithMessage("initialization failed")),
 		)
 	})

--- a/internal/test/marker/marker_test.go
+++ b/internal/test/marker/marker_test.go
@@ -782,7 +782,7 @@ func loadMarkerTest(name string, content []byte) (*markerTest, error) {
 			// testdata", so don't allow it as a module name (golang/go#65406).
 			// (Otherwise files within it will end up in an ad hoc
 			// package, "command-line-arguments/$TMPDIR/...".)
-			if filepath.Base(file.Name) == "go.mod" &&
+			if filepath.Base(file.Name) == "gno.mod" &&
 				bytes.Contains(file.Data, []byte("module testdata")) {
 				return nil, fmt.Errorf("'testdata' is not a valid module name")
 			}

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -450,7 +450,7 @@ func NeedsLocalXTools(t testing.TB) {
 
 	// We found the directory where x/tools would exist if we're in a clone of the
 	// repo. Is it there? (If not, we're probably in the module cache instead.)
-	modFilePath := filepath.Join(dir, "go.mod")
+	modFilePath := filepath.Join(dir, "gno.mod")
 	b, err := os.ReadFile(modFilePath)
 	if err != nil {
 		t.Skipf("skipping test: x/tools replacement not found: %v", err)

--- a/internal/testfiles/testfiles.go
+++ b/internal/testfiles/testfiles.go
@@ -25,7 +25,7 @@ import (
 // to the relative path "new" within the directory.
 //
 // Renaming allows tests to hide files whose names have
-// special meaning, such as "go.mod" files or "testdata" directories
+// special meaning, such as "gno.mod" files or "testdata" directories
 // from the go command, or ill-formed Go source files from gofmt.
 //
 // For example if we copy the directory testdata:

--- a/internal/work/completion.go
+++ b/internal/work/completion.go
@@ -97,7 +97,7 @@ func Completion(ctx context.Context, snapshot *cache.Snapshot, fh file.Handle, p
 		}
 
 		// Check for a match (a module directory).
-		if filepath.Base(rel) == "go.mod" {
+		if filepath.Base(rel) == "gno.mod" {
 			relDir := strings.TrimSuffix(dirNonClean(rel), string(os.PathSeparator))
 			completionPath := join(pathPrefixSlashDir, filepath.ToSlash(relDir))
 

--- a/internal/work/diagnostics.go
+++ b/internal/work/diagnostics.go
@@ -88,5 +88,5 @@ func modFileURI(pw *cache.ParsedWorkFile, use *modfile.Use) protocol.DocumentURI
 		modroot = filepath.Join(workdir, modroot)
 	}
 
-	return protocol.URIFromPath(filepath.Join(modroot, "go.mod"))
+	return protocol.URIFromPath(filepath.Join(modroot, "gno.mod"))
 }

--- a/release/release.go
+++ b/release/release.go
@@ -58,7 +58,7 @@ func main() {
 }
 
 func validateGoModFile(goplsDir string) error {
-	filename := filepath.Join(goplsDir, "go.mod")
+	filename := filepath.Join(goplsDir, "gno.mod")
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR updates some leftover references from `go.mod` to `gno.mod`.