### PR TITLE
fix(resolver): avoid panic when loading stdlibs

### DIFF
--- a/pkg/resolver/driver.go
+++ b/pkg/resolver/driver.go
@@ -59,6 +59,11 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 				return nil
 			}
 
+			// Skip the root directory itself, as "." is not a valid package path
+			if path == "." {
+				return nil
+			}
+
 			pkgDir := filepath.Join(libsRoot, path)
 
 			pkgs := readPkg(req, pkgDir, path, logger)


### PR DESCRIPTION
This PR fixes the error `panic: invalid package path "."` that occurs when `gnopls` tries to load standard library packages.

This happens in `github.com/gnolang/gno/gnovm/pkg/gnolang/mempackage.go:447`, inside the `MemPackageType.Decide()` function, due to a breaking change introduced in https://github.com/gnolang/gno/commit/36dc78f81eb87469c4887f5d2da402d83bb44b0f.
  - That commit added strict package path validation in `MemPackageType.Decide()`, now requiring all package paths to match either `Stdlib` or `Userlib` patterns.
  - `gnopls` uses `fs.WalkDir(os.DirFS(libsRoot), ".", ...)` to walk the standard library directory; this visits the root directory first (with path `.`).
  - `.` does not match either pattern, which causes the panic.

