### PR TITLE
feat(builtin): add revive and istypednil with documentation

### DIFF
--- a/pkg/gnotypes/builtin/builtin.gno
+++ b/pkg/gnotypes/builtin/builtin.gno
@@ -377,3 +377,29 @@ type realm interface {
 	Origin() realm
 	String() string
 }
+
+// The revive built-in function executes a function and captures any exception that
+// crosses a realm finalization boundary, returning it instead of aborting the program.
+//
+// In Gno's multi-user environment, when a panic crosses a realm boundary (as defined by
+// explicit cross-calls with fn(cross, ...) or implicit method calls on external realm
+// objects), the Machine normally aborts the program rather than allowing recover(), since
+// realm panics often leave state in an invalid state. The revive function allows tests
+// and controlled code to detect and handle these cross-realm aborts.
+//
+// If the function fn causes an exception that crosses a realm boundary, revive returns
+// that exception value. If fn completes normally or panics without crossing a realm
+// boundary, revive returns nil.
+//
+// Example:
+//
+//	abort := revive(func() {
+//	    myapp.CrossingFunc(cross, "arg")  // might panic across realm boundary
+//	})
+//	if abort != nil {
+//	    println("Cross-realm abort occurred:", abort)
+//	}
+//
+// Current behavior: This function is only enabled in testing mode. The function is not
+// cache-wrapped, so state mutations made during fn's execution remain even after an abort.
+func revive(fn func()) any

--- a/pkg/gnotypes/builtin/builtin.gno
+++ b/pkg/gnotypes/builtin/builtin.gno
@@ -403,3 +403,22 @@ type realm interface {
 // Current behavior: This function is only enabled in testing mode. The function is not
 // cache-wrapped, so state mutations made during fn's execution remain even after an abort.
 func revive(fn func()) any
+
+// The istypednil built-in function determines whether a value is a "typed nil" - a nil
+// value that has a type associated with it, such as (*int)(nil), []string(nil), or
+// map[string]int(nil).
+//
+// istypednil returns true when the value is nil and has an associated type in one of
+// these categories: Slice, Func, Map, Interface, Pointer, or Chan. It returns false
+// for untyped nil or non-nil values.
+//
+// Since reflect is not available in Gno, this function is useful for testing and
+// debugging scenarios where the distinction between typed and untyped nil matters.
+//
+// Example:
+//
+//	var ptr *int = nil
+//	istypednil(ptr)       // returns true
+//	istypednil(nil)       // returns false (untyped nil)
+//	istypednil(42)        // returns false (non-nil value)
+func istypednil(x any) bool

--- a/pkg/gnotypes/builtin_test.go
+++ b/pkg/gnotypes/builtin_test.go
@@ -69,6 +69,20 @@ func TestRevive() {
 }`, pkgName)
 		process(pkgName, content)
 	})
+
+	t.Run("istypednil usage", func(t *testing.T) {
+		content := fmt.Sprintf(`package %s
+func TestIsTypedNil() {
+	var ptr *int = nil
+	var slice []string = nil
+
+	result1 := istypednil(ptr)
+	result2 := istypednil(slice)
+	result3 := istypednil(nil)
+	_, _, _ = result1, result2, result3
+}`, pkgName)
+		process(pkgName, content)
+	})
 }
 
 type importerFunc func(path string) (*types.Package, error)

--- a/pkg/gnotypes/builtin_test.go
+++ b/pkg/gnotypes/builtin_test.go
@@ -58,6 +58,17 @@ func itscrossing(_ realm) {
 			process(pkgName, content)
 		}
 	})
+
+	t.Run("revive usage", func(t *testing.T) {
+		content := fmt.Sprintf(`package %s
+func TestRevive() {
+	result := revive(func() {
+		panic("test panic")
+	})
+	_ = result
+}`, pkgName)
+		process(pkgName, content)
+	})
 }
 
 type importerFunc func(path string) (*types.Package, error)
@@ -93,7 +104,6 @@ func MyInterface interface {
 	if err != nil {
 		t.Fatalf("export: %v", err) // any failure to export is a bug
 	}
-
 }
 
 func TestGnoBuiltinExporterVar(t *testing.T) {
@@ -127,5 +137,4 @@ func init() {
 	if err != nil {
 		t.Fatalf("export: %v", err) // any failure to export is a bug
 	}
-
 }


### PR DESCRIPTION
Add both the `revive`and `istypednil` builtin functions to gno builtin with comprehensive documentation.