### PR TITLE
fix(resolver): import test stdlibs

### DIFF
--- a/internal/cmd/resolver.go
+++ b/internal/cmd/resolver.go
@@ -51,7 +51,7 @@ func (*Resolver) Run(ctx context.Context, args ...string) error {
 
 	reqBytes, err := io.ReadAll(os.Stdin)
 	if err != nil {
-		return fmt.Errorf("failed to read request: %w", err.Error)
+		return fmt.Errorf("failed to read request: %v", err.Error())
 	}
 
 	req := packages.DriverRequest{}

--- a/internal/pkgbits/pkgbits_test.go
+++ b/internal/pkgbits/pkgbits_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/tools/internal/pkgbits"
+	"github.com/gnoverse/gnopls/internal/pkgbits"
 )
 
 func TestRoundTrip(t *testing.T) {
@@ -35,8 +35,10 @@ func TestRoundTrip(t *testing.T) {
 }
 
 // Type checker to enforce that know V* have the constant values they must have.
-var _ [0]bool = [pkgbits.V0]bool{}
-var _ [1]bool = [pkgbits.V1]bool{}
+var (
+	_ [0]bool = [pkgbits.V0]bool{}
+	_ [1]bool = [pkgbits.V1]bool{}
+)
 
 func TestVersions(t *testing.T) {
 	type vfpair struct {

--- a/internal/testfiles/testfiles_test.go
+++ b/internal/testfiles/testfiles_test.go
@@ -10,11 +10,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gnoverse/gnopls/internal/testenv"
+	"github.com/gnoverse/gnopls/internal/testfiles"
+	"github.com/gnoverse/gnopls/internal/versions"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
-	"golang.org/x/tools/internal/testenv"
-	"golang.org/x/tools/internal/testfiles"
-	"golang.org/x/tools/internal/versions"
 	"golang.org/x/tools/txtar"
 )
 

--- a/pkg/resolver/driver.go
+++ b/pkg/resolver/driver.go
@@ -50,6 +50,10 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 	if gnoRoot != "" {
 		libsRoot := filepath.Join(gnoRoot, "gnovm", "stdlibs")
 		testLibsRoot := filepath.Join(gnoRoot, "gnovm", "tests", "stdlibs")
+
+		// Track which packages we've already processed from libsRoot
+		processedPkgs := make(map[string]bool)
+
 		if err := fs.WalkDir(os.DirFS(libsRoot), ".", func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return nil
@@ -76,6 +80,7 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 				if !strings.HasSuffix(pkg.Name, "_test") {
 					pkgsCache[path] = pkg
 				}
+				processedPkgs[path] = true
 
 				testLibDir := filepath.Join(testLibsRoot, path)
 				testsDir, err := os.ReadDir(testLibDir)
@@ -110,6 +115,46 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 			return nil
 		}); err != nil {
 			logger.Warn("failed to inject all stdlibs", slog.String("error", err.Error()))
+		}
+
+		// Inject test-only stdlibs (packages that exist only in tests/stdlibs)
+		if err := fs.WalkDir(os.DirFS(testLibsRoot), ".", func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+
+			if !d.IsDir() {
+				return nil
+			}
+
+			if path == "." {
+				return nil
+			}
+
+			// Skip if we already processed this package from libsRoot
+			if processedPkgs[path] {
+				return nil
+			}
+
+			pkgDir := filepath.Join(testLibsRoot, path)
+
+			pkgs := readPkg(req, pkgDir, path, logger)
+			for _, pkg := range pkgs {
+				if len(pkg.GoFiles) == 0 {
+					continue
+				}
+
+				res.Packages = append(res.Packages, pkg)
+				if !strings.HasSuffix(pkg.Name, "_test") {
+					pkgsCache[path] = pkg
+				}
+			}
+
+			// logger.Info("injected test-only stdlib", slog.String("path", path))
+
+			return nil
+		}); err != nil {
+			logger.Warn("failed to inject test-only stdlibs", slog.String("error", err.Error()))
 		}
 	}
 

--- a/pkg/resolver/driver.go
+++ b/pkg/resolver/driver.go
@@ -121,7 +121,13 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 		if file == "..." {
 			gnomodsRes, err := listPackagesPath(dir)
 			if err != nil {
-				logger.Error("failed to get pkg list", slog.String("error", err.Error()))
+				logger.Error(
+					"failed to get pkg list",
+					slog.String("target", target),
+					slog.String("file", file),
+					slog.String("dir", dir),
+					slog.String("error", err.Error()),
+				)
 				return nil, err
 			}
 			pkgpaths = append(pkgpaths, gnomodsRes...)
@@ -129,7 +135,13 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 			dir = strings.TrimPrefix(dir, "file=")
 			gnomodsRes, err := listPackagesPath(dir)
 			if err != nil {
-				logger.Error("failed to get pkg", slog.String("error", err.Error()))
+				logger.Error(
+					"failed to get pkg",
+					slog.String("target", target),
+					slog.String("file", file),
+					slog.String("dir", dir),
+					slog.String("error", err.Error()),
+				)
 				return nil, err
 			}
 			if len(gnomodsRes) != 1 {


### PR DESCRIPTION
This PR fixes importing standard test libraries. Previously, importing `testing` caused `gnopls` to fail with: 
> Error: no package data for import "testing".

The commit https://github.com/gnoverse/gnopls/commit/cc8d4f19d7f99e28d82a8b783eba1b9d730bcb3e fixes this. It’s not an ideal solution since it just adds another block to the already monolithic `Resolve` function which would benefit from a proper refactor for maintainability and testability. 

But since `Resolve` will likely be heavily changed when gno workspace support is implemented, this temporary fix is sufficient for now.

Other commits include several small fixes and logging improvements.