### PR TITLE
feat(resolver): add gnowork.toml-based workspace discovery for cross-package import resolution

### DIFF
--- a/internal/drivertest/driver.go
+++ b/internal/drivertest/driver.go
@@ -60,6 +60,7 @@ func main() {
 		Env:        append(request.Env, "GOPACKAGESDRIVER=off"), // avoid recursive invocation
 		BuildFlags: request.BuildFlags,
 		Tests:      request.Tests,
+		Dir:        request.Dir,
 		Overlay:    request.Overlay,
 	}
 	pkgs, err := packages.Load(&config, flag.Args()...)

--- a/internal/packages/external.go
+++ b/internal/packages/external.go
@@ -34,6 +34,9 @@ type DriverRequest struct {
 	// Tests specifies whether the patterns should also return test packages.
 	Tests bool `json:"tests"`
 
+	// Dir is the working directory associated with the load request.
+	Dir string `json:"dir"`
+
 	// Overlay maps file paths (relative to the driver's working directory)
 	// to the contents of overlay files (see Config.Overlay).
 	Overlay map[string][]byte `json:"overlay"`
@@ -92,6 +95,7 @@ func findExternalDriver(cfg *Config) driver {
 		Env:        cfg.Env,
 		BuildFlags: cfg.BuildFlags,
 		Tests:      cfg.Tests,
+		Dir:        cfg.Dir,
 		Overlay:    cfg.Overlay,
 	}
 

--- a/pkg/resolver/driver.go
+++ b/pkg/resolver/driver.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"go/build"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -37,6 +38,8 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 	if err != nil {
 		logger.Warn("can't find gno root, examples and std packages are ignored", slog.String("error", err.Error()))
 	}
+
+	patterns = normalizePatterns(req, patterns)
 
 	targets := append([]string{}, patterns...)
 	if workspaceRoot := discoverWorkspaceRoot(patterns); workspaceRoot != "" {
@@ -271,6 +274,54 @@ func discoverWorkspaceRoot(patterns []string) string {
 	}
 
 	return findWorkspaceRoot(seedDir)
+}
+
+func normalizePatterns(req *packages.DriverRequest, patterns []string) []string {
+	if len(patterns) == 0 {
+		return nil
+	}
+
+	baseDir := ""
+	if req != nil {
+		baseDir = req.Dir
+	}
+
+	normalized := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		normalized = append(normalized, normalizePattern(pattern, baseDir))
+	}
+	return normalized
+}
+
+func normalizePattern(pattern string, baseDir string) string {
+	if path, ok := strings.CutPrefix(pattern, filePatternPrefix); ok {
+		return filePatternPrefix + normalizePath(path, baseDir)
+	}
+
+	if base, ok := strings.CutSuffix(pattern, recursivePattern); ok {
+		if isFilesystemPath(base) {
+			return filepath.Join(normalizePath(base, baseDir), recursivePattern)
+		}
+	}
+
+	return pattern
+}
+
+func normalizePath(path string, baseDir string) string {
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) || baseDir == "" {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(baseDir, path))
+}
+
+// isFilesystemPath reports whether path looks like a filesystem path rather
+// than a module/package path (e.g. "gno.land/foo/bar/"). Filesystem paths
+// are absolute, start with "./" or "../", or are empty (representing ".").
+func isFilesystemPath(path string) bool {
+	return path == "" || filepath.IsAbs(path) || build.IsLocalImport(path)
 }
 
 func workspaceSeedDir(patterns []string) string {

--- a/pkg/resolver/driver.go
+++ b/pkg/resolver/driver.go
@@ -30,7 +30,10 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 		logger.Warn("can't find gno root, examples and std packages are ignored", slog.String("error", err.Error()))
 	}
 
-	targets := patterns
+	targets := append([]string{}, patterns...)
+	if workspaceRoot := discoverWorkspaceRoot(patterns); workspaceRoot != "" {
+		targets = append(targets, filepath.Join(workspaceRoot, "..."))
+	}
 
 	if gnoRoot != "" {
 		targets = append(targets, filepath.Join(gnoRoot, "examples", "..."))
@@ -251,4 +254,75 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 	}
 
 	return &res, nil
+}
+
+func discoverWorkspaceRoot(patterns []string) string {
+	seedDir := workspaceSeedDir(patterns)
+	if seedDir == "" {
+		return ""
+	}
+
+	return findWorkspaceRoot(seedDir)
+}
+
+func workspaceSeedDir(patterns []string) string {
+	for _, pattern := range patterns {
+		if path, ok := strings.CutPrefix(pattern, "file="); ok {
+			return filepath.Dir(path)
+		}
+
+		if base, ok := strings.CutSuffix(pattern, "..."); ok {
+			return base
+		}
+	}
+
+	return ""
+}
+
+func findWorkspaceRoot(seedDir string) string {
+	if seedDir == "" {
+		return ""
+	}
+
+	seedDir = filepath.Clean(seedDir)
+	origSeedDir := seedDir
+	for {
+		if fileExists(filepath.Join(seedDir, "gnowork.toml")) {
+			return seedDir
+		}
+
+		parent := filepath.Dir(seedDir)
+		if parent == seedDir {
+			break
+		}
+		seedDir = parent
+	}
+
+	if hasGnoModule(origSeedDir) {
+		return origSeedDir
+	}
+
+	return ""
+}
+
+// gnoModFiles lists the recognized module definition file names for Gno
+// packages, checked in priority order (gnomod.toml takes precedence).
+var gnoModFiles = []string{"gnomod.toml", "gno.mod"}
+
+// hasGnoModule reports whether dir contains a Gno module definition file.
+func hasGnoModule(dir string) bool {
+	for _, f := range gnoModFiles {
+		if fileExists(filepath.Join(dir, f)) {
+			return true
+		}
+	}
+	return false
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
 }

--- a/pkg/resolver/driver.go
+++ b/pkg/resolver/driver.go
@@ -13,6 +13,14 @@ import (
 	"github.com/gnoverse/gnopls/pkg/eventlogger"
 )
 
+const (
+	filePatternPrefix   = "file="
+	recursivePattern    = "..."
+	workspaceConfigFile = "gnowork.toml"
+	gnoModTomlFile      = "gnomod.toml"
+	gnoModFile          = "gno.mod"
+)
+
 func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverResponse, error) {
 	logger := eventlogger.EventLoggerWrapper()
 
@@ -32,11 +40,11 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 
 	targets := append([]string{}, patterns...)
 	if workspaceRoot := discoverWorkspaceRoot(patterns); workspaceRoot != "" {
-		targets = append(targets, filepath.Join(workspaceRoot, "..."))
+		targets = append(targets, filepath.Join(workspaceRoot, recursivePattern))
 	}
 
 	if gnoRoot != "" {
-		targets = append(targets, filepath.Join(gnoRoot, "examples", "..."))
+		targets = append(targets, filepath.Join(gnoRoot, "examples", recursivePattern))
 	}
 
 	pkgsCache := map[string]*packages.Package{}
@@ -166,7 +174,7 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 	pkgpaths := []string{}
 	for _, target := range targets {
 		dir, file := filepath.Split(target)
-		if file == "..." {
+		if file == recursivePattern {
 			gnomodsRes, err := listPackagesPath(dir)
 			if err != nil {
 				logger.Error(
@@ -179,8 +187,8 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 				return nil, err
 			}
 			pkgpaths = append(pkgpaths, gnomodsRes...)
-		} else if strings.HasPrefix(target, "file=") {
-			dir = strings.TrimPrefix(dir, "file=")
+		} else if strings.HasPrefix(target, filePatternPrefix) {
+			dir = strings.TrimPrefix(dir, filePatternPrefix)
 			gnomodsRes, err := listPackagesPath(dir)
 			if err != nil {
 				logger.Error(
@@ -267,11 +275,11 @@ func discoverWorkspaceRoot(patterns []string) string {
 
 func workspaceSeedDir(patterns []string) string {
 	for _, pattern := range patterns {
-		if path, ok := strings.CutPrefix(pattern, "file="); ok {
+		if path, ok := strings.CutPrefix(pattern, filePatternPrefix); ok {
 			return filepath.Dir(path)
 		}
 
-		if base, ok := strings.CutSuffix(pattern, "..."); ok {
+		if base, ok := strings.CutSuffix(pattern, recursivePattern); ok {
 			return base
 		}
 	}
@@ -287,7 +295,7 @@ func findWorkspaceRoot(seedDir string) string {
 	seedDir = filepath.Clean(seedDir)
 	origSeedDir := seedDir
 	for {
-		if fileExists(filepath.Join(seedDir, "gnowork.toml")) {
+		if fileExists(filepath.Join(seedDir, workspaceConfigFile)) {
 			return seedDir
 		}
 
@@ -307,7 +315,7 @@ func findWorkspaceRoot(seedDir string) string {
 
 // gnoModFiles lists the recognized module definition file names for Gno
 // packages, checked in priority order (gnomod.toml takes precedence).
-var gnoModFiles = []string{"gnomod.toml", "gno.mod"}
+var gnoModFiles = []string{gnoModTomlFile, gnoModFile}
 
 // hasGnoModule reports whether dir contains a Gno module definition file.
 func hasGnoModule(dir string) bool {

--- a/pkg/resolver/driver.go
+++ b/pkg/resolver/driver.go
@@ -295,26 +295,38 @@ func normalizePatterns(req *packages.DriverRequest, patterns []string) []string 
 
 func normalizePattern(pattern string, baseDir string) string {
 	if path, ok := strings.CutPrefix(pattern, filePatternPrefix); ok {
-		return filePatternPrefix + normalizePath(path, baseDir)
+		normalized, resolved := resolvePath(path, baseDir)
+		if !resolved {
+			return pattern
+		}
+		return filePatternPrefix + normalized
 	}
 
 	if base, ok := strings.CutSuffix(pattern, recursivePattern); ok {
 		if isFilesystemPath(base) {
-			return filepath.Join(normalizePath(base, baseDir), recursivePattern)
+			normalized, resolved := resolvePath(base, baseDir)
+			if !resolved {
+				return pattern
+			}
+			return filepath.Join(normalized, recursivePattern)
 		}
 	}
 
 	return pattern
 }
 
-func normalizePath(path string, baseDir string) string {
+// resolvePath returns an absolute, cleaned form of path.
+func resolvePath(path string, baseDir string) (string, bool) {
 	if path == "" {
-		return ""
+		return "", true
 	}
-	if filepath.IsAbs(path) || baseDir == "" {
-		return filepath.Clean(path)
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), true
 	}
-	return filepath.Clean(filepath.Join(baseDir, path))
+	if baseDir == "" {
+		return "", false
+	}
+	return filepath.Clean(filepath.Join(baseDir, path)), true
 }
 
 // isFilesystemPath reports whether path looks like a filesystem path rather

--- a/pkg/resolver/driver.go
+++ b/pkg/resolver/driver.go
@@ -41,7 +41,7 @@ func Resolve(req *packages.DriverRequest, patterns ...string) (*packages.DriverR
 
 	patterns = normalizePatterns(req, patterns)
 
-	targets := append([]string{}, patterns...)
+	targets := slices.Clone(patterns)
 	if workspaceRoot := discoverWorkspaceRoot(patterns); workspaceRoot != "" {
 		targets = append(targets, filepath.Join(workspaceRoot, recursivePattern))
 	}

--- a/pkg/resolver/driver_test.go
+++ b/pkg/resolver/driver_test.go
@@ -1,0 +1,125 @@
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gnoverse/gnopls/internal/packages"
+)
+
+func TestDiscoverWorkspaceRootFallbacks(t *testing.T) {
+	t.Run("empty patterns", func(t *testing.T) {
+		if got := discoverWorkspaceRoot(nil); got != "" {
+			t.Fatalf("discoverWorkspaceRoot() = %q, want empty", got)
+		}
+	})
+
+	t.Run("no workspace and no module", func(t *testing.T) {
+		root := t.TempDir()
+		got := discoverWorkspaceRoot([]string{"file=" + filepath.Join(root, "main.gno")})
+		if got != "" {
+			t.Fatalf("discoverWorkspaceRoot() = %q, want empty", got)
+		}
+	})
+}
+
+func TestDiscoverWorkspaceRootFromFilePattern(t *testing.T) {
+	root := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(root, "gnowork.toml"), "")
+	mustWriteFile(t, filepath.Join(root, "r", "myapp", "gnomod.toml"), `module = "gno.land/r/myapp"`+"\n")
+	mustWriteFile(t, filepath.Join(root, "r", "myapp", "myapp.gno"), "package myapp\n")
+
+	got := discoverWorkspaceRoot([]string{"file=" + filepath.Join(root, "r", "myapp", "myapp.gno")})
+	if got != root {
+		t.Fatalf("discoverWorkspaceRoot() = %q, want %q", got, root)
+	}
+}
+
+func TestDiscoverWorkspaceRootFallsBackToSeedModule(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "gnomod.toml"), `module = "gno.land/r/myapp"`+"\n")
+
+	got := discoverWorkspaceRoot([]string{filepath.Join(root, "...")})
+	if got != root {
+		t.Fatalf("discoverWorkspaceRoot() = %q, want %q", got, root)
+	}
+}
+
+func TestResolveDiscoversWorkspacePackages(t *testing.T) {
+	root := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(root, "gnowork.toml"), "")
+	mustWriteFile(t, filepath.Join(root, "p", "mylib", "gnomod.toml"), `module = "gno.land/p/mylib"`+"\n")
+	mustWriteFile(t, filepath.Join(root, "p", "mylib", "mylib.gno"), "package mylib\n\nfunc Name() string {\n\treturn \"mylib\"\n}\n")
+	mustWriteFile(t, filepath.Join(root, "r", "myapp", "gnomod.toml"), `module = "gno.land/r/myapp"`+"\n")
+	mustWriteFile(t, filepath.Join(root, "r", "myapp", "myapp.gno"), "package myapp\n\nimport \"gno.land/p/mylib\"\n\nfunc Use() string {\n\treturn mylib.Name()\n}\n")
+
+	res, err := Resolve(&packages.DriverRequest{}, "file="+filepath.Join(root, "r", "myapp", "myapp.gno"))
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	pkgs := make(map[string]*packages.Package)
+	for _, pkg := range res.Packages {
+		pkgs[pkg.PkgPath] = pkg
+	}
+
+	lib := pkgs["gno.land/p/mylib"]
+	if lib == nil {
+		t.Fatalf("workspace dependency package not discovered")
+	}
+
+	app := pkgs["gno.land/r/myapp"]
+	if app == nil {
+		t.Fatalf("workspace app package not discovered")
+	}
+
+	if got := app.Imports["gno.land/p/mylib"]; got != lib {
+		t.Fatalf("app import not resolved to workspace package: got %#v, want %#v", got, lib)
+	}
+}
+
+func TestResolveDeduplicatesWorkspaceTargets(t *testing.T) {
+	root := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(root, "gnowork.toml"), "")
+	mustWriteFile(t, filepath.Join(root, "p", "mylib", "gnomod.toml"), `module = "gno.land/p/mylib"`+"\n")
+	mustWriteFile(t, filepath.Join(root, "p", "mylib", "mylib.gno"), "package mylib\n")
+	mustWriteFile(t, filepath.Join(root, "r", "myapp", "gnomod.toml"), `module = "gno.land/r/myapp"`+"\n")
+	mustWriteFile(t, filepath.Join(root, "r", "myapp", "myapp.gno"), "package myapp\n")
+
+	res, err := Resolve(&packages.DriverRequest{}, filepath.Join(root, "r", "myapp", "..."))
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	var appCount, libCount int
+	for _, pkg := range res.Packages {
+		switch pkg.PkgPath {
+		case "gno.land/r/myapp":
+			appCount++
+		case "gno.land/p/mylib":
+			libCount++
+		}
+	}
+
+	if appCount != 1 {
+		t.Fatalf("myapp package count = %d, want 1", appCount)
+	}
+	if libCount != 1 {
+		t.Fatalf("mylib package count = %d, want 1", libCount)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}

--- a/pkg/resolver/driver_test.go
+++ b/pkg/resolver/driver_test.go
@@ -47,6 +47,35 @@ func TestDiscoverWorkspaceRootFallsBackToSeedModule(t *testing.T) {
 	}
 }
 
+func TestResolveUsesRequestDirForRelativeWorkspacePattern(t *testing.T) {
+	root := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(root, "gnowork.toml"), "")
+	mustWriteFile(t, filepath.Join(root, "p", "mylib", "gnomod.toml"), `module = "gno.land/p/mylib"`+"\n")
+	mustWriteFile(t, filepath.Join(root, "p", "mylib", "mylib.gno"), "package mylib\n")
+	mustWriteFile(t, filepath.Join(root, "r", "myapp", "gnomod.toml"), `module = "gno.land/r/myapp"`+"\n")
+	mustWriteFile(t, filepath.Join(root, "r", "myapp", "myapp.gno"), "package myapp\n\nimport \"gno.land/p/mylib\"\n")
+
+	res, err := Resolve(&packages.DriverRequest{Dir: root}, "./...")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	pkgs := make(map[string]*packages.Package)
+	for _, pkg := range res.Packages {
+		pkgs[pkg.PkgPath] = pkg
+	}
+
+	app := pkgs["gno.land/r/myapp"]
+	lib := pkgs["gno.land/p/mylib"]
+	if app == nil || lib == nil {
+		t.Fatalf("relative workspace load missed packages: app=%v lib=%v", app != nil, lib != nil)
+	}
+	if got := app.Imports["gno.land/p/mylib"]; got != lib {
+		t.Fatalf("relative workspace import not resolved to workspace package: got %#v, want %#v", got, lib)
+	}
+}
+
 func TestResolveDiscoversWorkspacePackages(t *testing.T) {
 	root := t.TempDir()
 

--- a/pkg/resolver/driver_test.go
+++ b/pkg/resolver/driver_test.go
@@ -142,6 +142,30 @@ func TestResolveDeduplicatesWorkspaceTargets(t *testing.T) {
 	}
 }
 
+func TestNormalizePatternPreservesRelativeWithoutBaseDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		baseDir string
+		want    string
+	}{
+		{name: "recursive relative no base", pattern: "./...", baseDir: "", want: "./..."},
+		{name: "recursive parent relative no base", pattern: "../foo/...", baseDir: "", want: "../foo/..."},
+		{name: "file relative no base", pattern: "file=./main.gno", baseDir: "", want: "file=./main.gno"},
+		{name: "module pattern unchanged", pattern: "gno.land/r/foo/...", baseDir: "", want: "gno.land/r/foo/..."},
+		{name: "absolute path cleaned without base", pattern: "/abs/./path/...", baseDir: "", want: "/abs/path/..."},
+		{name: "relative resolved against base", pattern: "./...", baseDir: "/work", want: "/work/..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizePattern(tt.pattern, tt.baseDir); got != tt.want {
+				t.Fatalf("normalizePattern(%q, %q) = %q, want %q", tt.pattern, tt.baseDir, got, tt.want)
+			}
+		})
+	}
+}
+
 func mustWriteFile(t *testing.T, path string, content string) {
 	t.Helper()
 

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -7,7 +7,6 @@ import (
 	"go/token"
 	"io/fs"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -41,14 +40,8 @@ func listPackagesPath(root string) ([]string, error) {
 			return nil
 		}
 
-		for _, fname := range []string{"gnomod.toml", "gno.mod"} {
-			fpath := filepath.Join(path, fname)
-			if _, err := os.Stat(fpath); err != nil {
-				continue
-			}
-
+		if hasGnoModule(path) {
 			gnomods = append(gnomods, path)
-			break
 		}
 		return nil
 	})

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -40,6 +40,10 @@ func listPackagesPath(root string) ([]string, error) {
 			return nil
 		}
 
+		if path != root && fileExists(filepath.Join(path, workspaceConfigFile)) {
+			return filepath.SkipDir
+		}
+
 		if hasGnoModule(path) {
 			gnomods = append(gnomods, path)
 		}

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -1,0 +1,46 @@
+package resolver
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestListPackagesPathSkipsNestedWorkspace(t *testing.T) {
+	root := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(root, "gnowork.toml"), "")
+	mustWriteFile(t, filepath.Join(root, "p", "parentlib", "gnomod.toml"), `module = "gno.land/p/parentlib"`+"\n")
+	mustWriteFile(t, filepath.Join(root, "sub", "gnowork.toml"), "")
+	mustWriteFile(t, filepath.Join(root, "sub", "p", "childlib", "gnomod.toml"), `module = "gno.land/p/childlib"`+"\n")
+
+	got, err := listPackagesPath(root)
+	if err != nil {
+		t.Fatalf("listPackagesPath() error = %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("listPackagesPath() count = %d, want 1 (%v)", len(got), got)
+	}
+	if got[0] != filepath.Join(root, "p", "parentlib") {
+		t.Fatalf("listPackagesPath() = %v, want only parent workspace package", got)
+	}
+}
+
+func TestListPackagesPathKeepsRootWorkspace(t *testing.T) {
+	root := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(root, "gnowork.toml"), "")
+	mustWriteFile(t, filepath.Join(root, "r", "myapp", "gnomod.toml"), `module = "gno.land/r/myapp"`+"\n")
+
+	got, err := listPackagesPath(root)
+	if err != nil {
+		t.Fatalf("listPackagesPath() error = %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("listPackagesPath() count = %d, want 1 (%v)", len(got), got)
+	}
+	if got[0] != filepath.Join(root, "r", "myapp") {
+		t.Fatalf("listPackagesPath() = %v, want root workspace package", got)
+	}
+}


### PR DESCRIPTION
## Description

closes #20 

gnopls could not resolve imports to sibling packages in the same monorepo because the resolver only walked directories covered by the incoming load patterns. Packages like `gno.land/p/gnoswap/uint256` were silently dropped as "missed imports" even though they existed locally.

This PR ports the Gno's workspace discovery strategy into the resolver:

- Discover workspace root by walking upward from the load target to find `gnowork.toml`
- Index all packages under the workspace root before resolving imports
- Skip nested sub-workspaces (`gnowork.toml` in subdirectories)
- Propagate `cfg.Dir` through `DriverRequest` so relative patterns like `./...` resolve against the actual workspace folder, not the process CWD

**Before**
<img width="1056" height="301" alt="스크린샷 2026-04-16 오전 11 52 24" src="https://github.com/user-attachments/assets/9325a0b8-d7fb-407b-a911-8b8218ba980c" />

**After**
<img width="1056" height="422" alt="스크린샷 2026-04-16 오전 11 58 23" src="https://github.com/user-attachments/assets/71f6ccee-09a3-4f82-974c-dac1f3164e26" />

